### PR TITLE
Fix remove-if-not is void.

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -317,7 +317,7 @@ WEBENGINE-INCLUDE-PRIVATE-CODEC is only useful when app-name is video-player."
 (defun lsp-bridge-get-completion-items ()
   (when (boundp 'lsp-bridge-completion-items)
     (let ((prefix (company-grab-symbol)))
-      (remove-if-not
+      (cl-remove-if-not
        (lambda (c)
          (string-prefix-p prefix c))
        lsp-bridge-completion-items))))


### PR DESCRIPTION
cl-lib: cl-remove-if-not
cl: remove-if-not

And Package cl is deprecated in Emacs-27 #35
https://github.com/kiwanami/emacs-epc/issues/35