### PR TITLE
fix: pyright pythonPath

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from core.utils import generate_request_id
+from core.utils import generate_request_id, get_emacs_var, eval_in_emacs
 from subprocess import PIPE
 from threading import Thread
 import json
@@ -427,6 +427,7 @@ class LspServer(object):
 
     def get_server_workspace_change_configuration(self):
         if self.server_type == "pyright":
+            eval_in_emacs("lsp-bridge-set-current-python-command", [])
             return {"settings": {
                 "analysis": {
                     "autoImportCompletions": True,
@@ -439,7 +440,7 @@ class LspServer(object):
                     "autoSearchPaths": True,
                     "extraPaths": []
                 },
-                "pythonPath": "/usr/bin/python",
+                "pythonPath": get_emacs_var("lsp-bridge-current-python-command"),
                 "venvPath": ""
             }}
         elif self.server_type == "solargraph":

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -160,6 +160,13 @@ Setting this to nil or 0 will turn off the indicator."
   "The Python interpreter used to run lsp-bridge.py."
   :type 'string)
 
+(defcustom lsp-bridge-current-python-command ""
+  "The Python interpreter for project, maybe a venv path."
+  :type 'string)
+
+(defun lsp-bridge-set-current-python-command ()
+  (setq lsp-bridge-current-python-command (executable-find "python")))
+
 (defcustom lsp-bridge-enable-debug nil
   "If you got segfault error, please turn this option.
 Then LSPBRIDGE will start by gdb, please send new issue with `*lsp-bridge*' buffer content when next crash."


### PR DESCRIPTION
初始化 pyright 的 python 取当前 active 的 python 路径，这样就能兼容虚拟环境了