### PR TITLE
Fix clangd server command parameters. (#21)

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -105,6 +105,9 @@ class LspBridgeListener(Thread):
                         self.emit_message(message)
             except:
                 traceback.print_exc()
+        print("\n--- Lsp server exited, exit code: {}".format(self.process.returncode))
+        print(self.process.stdout.read())
+        print(self.process.stderr.read())
 
 class SendRequest(Thread):
 

--- a/langserver/clangd.json
+++ b/langserver/clangd.json
@@ -4,10 +4,9 @@
     "command": [
         "clangd",
         "--all-scopes-completion",
-        "--cland-tidy",
+        "--clang-tidy",
         "--enable-config",
-        "--header-insertion-decorators=0",
-        "--inlay-hints"
+        "--header-insertion-decorators=0"
     ],
     "settings": {}
 }


### PR DESCRIPTION
1. Fix typo.
2. `inlay-hints=true` is only for clangd 13+ and has no effect on lsp-bridge.
3. Try print lsp server exit information for debugging.