### PR TITLE
Fix receiving messages from lsp servers

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -32,6 +32,10 @@ import subprocess
 import threading
 import traceback
 
+
+DEFAULT_BUFFER_SIZE = 100000000  # we need make buffer size big enough, avoid pipe hang by big data response from LSP server
+
+
 class JsonEncoder(json.JSONEncoder):
 
     def default(self, o): # pylint: disable=E0202
@@ -43,7 +47,7 @@ class LspBridgeListener(Thread):
         Thread.__init__(self)
 
         self.process = process
-        self.reader = io.BufferedReader(io.FileIO(self.process.stdout.fileno()))
+        self.reader = io.BufferedReader(io.FileIO(self.process.stdout.fileno()), buffer_size=DEFAULT_BUFFER_SIZE)
         self.lsp_message_queue = lsp_message_queue
         self.previous_message_ending_length = None
 
@@ -229,7 +233,7 @@ class LspServer(object):
 
         # Start LSP sever.
         self.p = subprocess.Popen(self.server_info["command"],
-                                  bufsize=100000000, # we need make buffer size big enough, avoid pipe hang by big data response from LSP server
+                                  bufsize=DEFAULT_BUFFER_SIZE,
                                   stdin=PIPE, stdout=PIPE, stderr=stderr)
         
         # Notify user server is start.

--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -49,7 +49,6 @@ class LspBridgeListener(Thread):
         self.process = process
         self.reader = io.BufferedReader(io.FileIO(self.process.stdout.fileno()), buffer_size=DEFAULT_BUFFER_SIZE)
         self.lsp_message_queue = lsp_message_queue
-        self.previous_message_ending_length = None
 
     def run(self):
         while self.process.poll() is None:

--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -51,37 +51,6 @@ class LspBridgeListener(Thread):
         self.lsp_message_queue = lsp_message_queue
         self.previous_message_ending_length = None
 
-    def is_beginning_number(self, string):
-        text = re.compile(r"^[0-9].*")
-        return text.match(string)
-        
-    def is_end_number(self, string):
-        text = re.compile(r".*[0-9]$")
-        return text.match(string)
-
-    def emit_message(self, line):
-        if line != "":
-            try:
-                # Copy message with line.
-                message = line
-                
-                # Try strip string before char '{'.
-                if not message.startswith("{"):
-                    message = message[message.find("{"):]
-                
-                # Try strip string after char '}'.
-                if not message.endswith("}"):
-                    message = message[:message.rfind("}") + 1]
-            
-                # Send message.
-                self.lsp_message_queue.put({
-                    "name": "lsp_recv_message",
-                    "content": json.loads(message)
-                })
-                
-            except:
-                traceback.print_exc()
-
     def run(self):
         while self.process.poll() is None:
             try:

--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -87,7 +87,7 @@ class LspBridgeListener(Thread):
 
                 # Read Content-Length
                 line = self.reader.readline()
-                logger.debug('READ LINE: ' + repr(line))
+                logger.debug('### content-length: ' + repr(line))
                 length = int(line[line.rfind(b":") + 1:].strip())
                 self.reader.readline()
                 message = self.reader.read(length)


### PR DESCRIPTION
使用 PyRight 时遇到了不少 “NOTE: This is a bug, the second line should be empty”。观察 log 后发现，在 JSON 消息后可能没有任何换行，Content-Length 直接贴在 } 的后面。

所以修复了一下读消息的部分代码，主要变更是（使用 BufferedReader）直接读出 Content-Length 大小的消息，这样就避免了消息被分成两部分时需要的 hack。