### PR TITLE
fix completion response annotation default

### DIFF
--- a/core/fileaction.py
+++ b/core/fileaction.py
@@ -189,7 +189,7 @@ class FileAction(object):
                         "label": item["label"],
                         "insertText": insertText,
                         "kind": kind,
-                        "annotation": item.get("detail", kind).replace(" ", ""),
+                        "annotation": (item.get("detail") or kind).replace(" ", ""),
                     }
                     
                     if (self.enable_auto_import):


### PR DESCRIPTION
This pull request fixes an exception using with solargraph:

```
--- Send request (1784): textDocument/completion

--- Recv response (1784): textDocument/completion
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/nix/store/nvxp3xmlrxj9sw66dk7l0grz9m4889jn-python3-3.9.12/lib/python3.9/threading.py", line 973, in _bootstrap_inner
    self.run()
  File "/nix/store/nvxp3xmlrxj9sw66dk7l0grz9m4889jn-python3-3.9.12/lib/python3.9/threading.py", line 910, in run
    self._target(*self._args, **self._kwargs)
  File "/home/xinyifly/.config/emacs/site-lisp/lsp-bridge/lsp-bridge.py", line 109, in message_dispatcher
    self.handle_server_message(*message["content"])
  File "/home/xinyifly/.config/emacs/site-lisp/lsp-bridge/lsp-bridge.py", line 189, in handle_server_message
    self.file_action_dict[filekey].handle_server_response_message(request_id, request_type, response_result)
  File "/home/xinyifly/.config/emacs/site-lisp/lsp-bridge/core/fileaction.py", line 143, in handle_server_response_message
    self.handle_completion_response(request_id, response_result)
  File "/home/xinyifly/.config/emacs/site-lisp/lsp-bridge/core/fileaction.py", line 192, in handle_completion_response
    "annotation": item.get("detail", kind).replace(" ", ""),
AttributeError: 'NoneType' object has no attribute 'replace'
```

The `item` variable somehow become:
```python
{'label': 'list_c', 'kind': 6, 'detail': None, 'data': {'path': None, 'return_type': 'undefined', 'location': {'filename': '/home/xinyifly/leetcode/160.intersection-of-two-linked-lists.rb', 'range': {'start': {'line': 143, 'character': 0}, 'end': {'line': 143, 'character': 58}}}, 'deprecated': False, 'uri': 'file:///home/xinyifly/leetcode/160.intersection-of-two-linked-lists.rb'}, 'textEdit': {'range': {'start': {'line': 150, 'character': 0}, 'end': {'line': 150, 'character': 0}}, 'newText': 'list_c'}, 'sortText': '0000list_c'}
```

Indicates that `detail` is an explicitly `None` which violates `dict.get(key[, default])` usage thus has no attribute 'replace'