### PR TITLE
Fix startup error install via straight

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -804,11 +804,9 @@ If optional MARKER, return a marker instead"
               (string-equal (buffer-name) "*Messages*"))
     (setq lsp-bridge--last-buffer (current-buffer))))
 
-;;;###autoload
-(add-hook 'post-command-hook 'lsp-bridge-monitor-window-buffer-change)
-
 (defconst lsp-bridge--internal-hooks
-  '((before-change-functions . lsp-bridge-monitor-before-change)
+  '((post-command-hook . lsp-bridge-monitor-window-buffer-change)
+    (before-change-functions . lsp-bridge-monitor-before-change)
     (after-change-functions . lsp-bridge-monitor-after-change)
     (post-command-hook . lsp-bridge-monitor-post-command)
     (after-save-hook . lsp-bridge-monitor-after-save)


### PR DESCRIPTION
I use straight.el to install this package, and here's an error on emacs stratup:

```
Error in post-command-hook (lsp-bridge-monitor-window-buffer-change): (void-function lsp-bridge-monitor-window-buffer-change)
```

A mini config to reproduce this:
```elisp
(defvar bootstrap-version)
(let ((bootstrap-file
       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
      (bootstrap-version 5))
  (unless (file-exists-p bootstrap-file)
    (with-current-buffer
        (url-retrieve-synchronously
         "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
         'silent 'inhibit-cookies)
      (goto-char (point-max))
      (eval-print-last-sexp)))
  (load bootstrap-file nil 'nomessage))

(straight-use-package '(lsp-bridge
                        :type git
                        :host github
                        :repo "manateelazycat/lsp-bridge"
                        :files (:defaults "*.py" "core/*" "langserver/*")))

```