### PR TITLE
fix command not found

### DIFF
--- a/lsp-bridge.py
+++ b/lsp-bridge.py
@@ -29,6 +29,7 @@ import queue
 import signal
 import sys
 import threading
+import traceback
 
 class LspBridge(object):
     def __init__(self, args):
@@ -131,7 +132,14 @@ class LspBridge(object):
         lsp_server_name = file_action.get_lsp_server_name()
         if lsp_server_name not in self.lsp_server_dict:
             # lsp server will send initialize and didOpen when open first file in project.
-            server = LspServer(self.message_queue, file_action)
+            try:
+                server = LspServer(self.message_queue, file_action)
+            except FileNotFoundError:
+                eval_in_emacs("message", [f"Server {file_action.lang_server_info['command']} not found, please install it."])
+                return
+            except:
+                traceback.print_exc()
+                return
             self.lsp_server_dict[lsp_server_name] = server
         else:
             # Send didOpen notification to LSP server.


### PR DESCRIPTION
使用场景是：如果我打开了 xxx.rs，但此时 rust-analyzer 还没有安装，就会直接挂掉，这时候我切到别的项目，比如说 go，gopls 是安装了的，但也没办法正常使用了，不知道这么改合不合适

```
Cache action change_cursor, wait for file /home/zy/projects/my/test/test.rs to open it before executing.
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/zy/.emacs.d/repo/lsp-bridge/lsp-bridge.py", line 92, in postgui_dispatcher
    self._open_file(message["content"])
  File "/home/zy/.emacs.d/repo/lsp-bridge/lsp-bridge.py", line 134, in _open_file
    server = LspServer(self.message_queue, file_action)
  File "/home/zy/.emacs.d/repo/lsp-bridge/core/lspserver.py", line 232, in __init__
    self.p = subprocess.Popen(self.server_info["command"],
  File "/usr/local/lib/python3.8/subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/lib/python3.8/subprocess.py", line 1704, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'rust-analyzer'

```