### PR TITLE
use lru_cache(maxsize=None)

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -188,7 +188,7 @@ def get_project_path(filepath):
         return filepath
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def get_emacs_version():
     return get_emacs_func_result("get-emacs-version")
 


### PR DESCRIPTION
functools.cache 3.9 版本才引入，还是挺新的，lru_cache 适用性更好些吧，3.2 以后都能用