### PR TITLE
Fix find define key error

### DIFF
--- a/core/handler/find_define.py
+++ b/core/handler/find_define.py
@@ -1,5 +1,6 @@
 from core.handler import Handler
 from core.utils import *
+from typing import Union
 
 
 class FindDefine(Handler):
@@ -10,12 +11,12 @@ class FindDefine(Handler):
     def process_request(self, position) -> dict:
         return dict(position=position)
 
-    def process_response(self, response: dict) -> None:
+    def process_response(self, response: Union[dict, list[dict]]) -> None:
         if not response:
             message_emacs("No definition found.")
             return
 
-        file_info = response[0]
+        file_info = response[0] if isinstance(response, list) else response
         # volar return only LocationLink (using targetUri)
         file_uri = file_info["uri"] if "uri" in file_info else file_info["targetUri"]
         range1 = file_info["range"] if "range" in file_info else file_info["targetRange"]


### PR DESCRIPTION
Currently when I use find def in `elixir` , `*lsp-bridge*` reports:
```
--- Send (56637): textDocument/definition

--- Recv response (56637): textDocument/definition
Error when processing response 56637
Traceback (most recent call last):
  File "/home/xinyifly/.config/emacs/site-lisp/lsp-bridge/core/handler/__init__.py", line 63, in handle_response
    self.process_response(response)
  File "/home/xinyifly/.config/emacs/site-lisp/lsp-bridge/core/handler/find_define.py", line 18, in process_response
    file_info = response[0]
KeyError: 0
```

Inspecting `response` I got:
```
{'range': {'end': {'character': 6, 'line': 1}, 'start': {'character': 6, 'line': 1}}, 'uri': 'file:///home/xinyifly/git/lino/device/lib/lino_device/gateway.ex'}
```

Which is a dict instead of a list of dict, this pull request handles that situation.