### PR TITLE
Add support textEdit

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -76,6 +76,7 @@
 (require 'map)
 (require 'seq)
 (require 'subr-x)
+(require 'dash)
 (require 'lsp-bridge-epc)
 (require 'lsp-bridge-ref)
 (require 'posframe)
@@ -444,6 +445,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
 (defvar-local lsp-bridge-completion-items nil)
 (defvar-local lsp-bridge-completion-prefix nil)
 (defvar-local lsp-bridge-completion-common nil)
+(defvar-local lsp-bridge-completion-trigger-characters nil)
 (defvar-local lsp-bridge-filepath "")
 
 (defun lsp-bridge-char-before ()
@@ -468,7 +470,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
            (string-empty-p (format "%s" (car list))))
       (and (eq (length list) 0))))
 
-(defun lsp-bridge-record-completion-items (filepath prefix common items)
+(defun lsp-bridge-record-completion-items (filepath prefix common items trigger-characters)
   ;; (message "*** '%s' '%s' '%s'" prefix common items)
 
   (lsp-bridge--with-file-buffer filepath
@@ -476,6 +478,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     (setq-local lsp-bridge-completion-items items)
     (setq-local lsp-bridge-completion-prefix prefix)
     (setq-local lsp-bridge-completion-common common)
+    (setq-local lsp-bridge-completion-trigger-characters trigger-characters)
 
     ;; Try popup completion frame.
     (unless (or
@@ -516,16 +519,28 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
 (defun lsp-bridge-capf ()
   "Capf function similar to eglot's 'eglot-completion-at-point'."
   (let* ((candidates (lsp-bridge-extract-candidates))
-         (bounds (bounds-of-thing-at-point 'symbol)))
+         (bounds-start (or (-some--> (cl-first (bounds-of-thing-at-point 'symbol))
+                               (save-excursion
+                                 (ignore-errors
+                                   (goto-char (+ it 1))
+                                   (while (lsp-bridge--looking-back-trigger-characterp
+                                           lsp-bridge-completion-trigger-characters)
+                                     (cl-incf it)
+                                     (forward-char))
+                                   it)))
+                             (point)))
+         prefix)
     (list
-     (or (car bounds) (point))
-     (or (cdr bounds) (point))
+     bounds-start
+     (point)
      candidates
      :annotation-function
      (lambda (candidate)
        "Extract annotation from CANDIDATE."
        (let* ((item (get-text-property 0 'lsp-bridge--lsp-item candidate))
               (annotation (plist-get item :annotation)))
+         ;; record prefix before corfu/company insert
+         (setq prefix (buffer-substring-no-properties bounds-start (point)))
          (when annotation
            (concat " "
                    (propertize annotation
@@ -543,22 +558,48 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
          ;; We need extract newest candidates when insert, avoid insert old candidate content.
          (let* ((newest-candidates (lsp-bridge-extract-candidates))
                 (item (get-text-property 0 'lsp-bridge--lsp-item (cl-find candidate newest-candidates :test #'string=)))
+                (label (plist-get item :label))
                 (insert-text (plist-get item :insertText))
+                (insert-text-format (plist-get item :insertTextFormat))
+                (textEdit (plist-get item :textEdit))
                 (additionalTextEdits (if lsp-bridge-enable-auto-import (plist-get item :additionalTextEdits) nil))
-                (kind (plist-get item :kind)))
-
+                (kind (plist-get item :kind))
+                (markers (list bounds-start (copy-marker (point) t)))
+                (snippet-fn (and (or (eql insert-text-format 2) (string= kind "Snippet")) (lsp-bridge--snippet-expansion-fn))))
            ;; Do auto-imprt action.
            (with-current-buffer
                (if (minibufferp) (window-buffer (minibuffer-selected-window))
                  (current-buffer))
+             (cond
+              (textEdit
+               ;; Remove candidate label and insert candidate insertText
+               (apply #'delete-region markers)
+               (insert prefix)
+               (let* ((range (plist-get textEdit :range))
+                      (newText (plist-get textEdit :newText)))
+                 (pcase-let ((`(,beg . ,end)
+                              (lsp-bridge--range-region range)))
+                   (delete-region beg end)
+                   (goto-char beg))
+                 (funcall (or snippet-fn #'insert) newText)))
+              (t
+               (delete-region (- (point) (length candidate)) (point))
+               (funcall (or snippet-fn #'insert) (or insert-text label))))
+             (when (cl-plusp (length additionalTextEdits))
+               (lsp-bridge--apply-text-edits additionalTextEdits)))))))))
 
-             (let ((snippet-fn (lsp-bridge--snippet-expansion-fn)))
-               (when insert-text
-                 (delete-region (- (point) (length candidate)) (point))
-                 (funcall (or snippet-fn #'insert) insert-text)
-                 (when (cl-plusp (length additionalTextEdits))
-                   (lsp-bridge--apply-text-edits additionalTextEdits)))))
-           ))))))
+
+;;; Copy from lsp-mode
+(defun lsp-bridge--looking-back-trigger-characterp (trigger-characters)
+  "Return trigger character if text before point match any of the TRIGGER-CHARACTERS."
+  (unless (= (point) (point-at-bol))
+    (seq-some
+     (lambda (trigger-char)
+       (and (equal (buffer-substring-no-properties (- (point) (length trigger-char)) (point))
+                   trigger-char)
+            trigger-char))
+     trigger-characters)))
+
 
 ;; Copy from eglot
 (defun lsp-bridge--snippet-expansion-fn ()


### PR DESCRIPTION
1. 引了个 dash 依赖，看看是不是可以替换；
2. 在 annotation-function 中用来记录了个 prefix 主要是拿 corfu-insert 插入之前的输入前缀，lsp-bridge-completion-prefix 记录的前缀在选中之后就是nil了，直接在 exit-function 中获取的是 corfu-insert 之后的内容，所以目前只想到在哪里能拿到想要的值；
