### PR TITLE
add xref support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Lsp-bridge uses python's threading technology to build caches that bridge Emacs 
 (require 'company-box)
 (company-box-mode 1)
 (global-lsp-bridge-mode)
+
+;; For Xref support
+(add-hook 'lsp-bridge-mode-hook (lambda ()
+  (add-hook 'xref-backend-functions #'lsp-bridge-xref-backend nil t)))
 ```
 
 ## Commands
@@ -58,10 +62,16 @@ Lsp-bridge uses python's threading technology to build caches that bridge Emacs 
 * lsp-bridge-find-impl-other-window: jump to the implementation in other-window
 * lsp-bridge-return-from-def: return to the location before calling `lsp-bridge-find-def`
 * lsp-bridge-find-references: traverse across code references (forked from color-rg.el)
-* lsp-bridge-lookup-documentation: lookup documentation of symbol under the cursor 
+* lsp-bridge-lookup-documentation: lookup documentation of symbol under the cursor
 * lsp-bridge-rename: rename symbol under the cursor
 * lsp-bridge-show-signature-help-in-minibuffer: show signature help in minibuffer manually (move cursor to parameters area will show signature help automatically)
 * lsp-bridge-restart-process: restart lsp-bridge process (only used for development)
+
+After enable Xref support, the commands for Xref is available, we currently supported and tested those:
+
+* xref-find-definitions: jump to the definition
+* xref-go-back: return to the location before calling `xref-find-definitions`
+* xref-go-forward: jump to the location before calling `xref-go-back`
 
 ## Customize language server configuration
 
@@ -107,7 +117,7 @@ Welcome to send PR to help us improve support for LSP servers, thanks for your c
 
 ### TODO Features:
 
-- [ ] Show signature help with eldoc 
+- [ ] Show signature help with eldoc
 - [ ] Code action
 - [ ] Inline Value
 - [ ] One file open multi-server, and mixed multi-result to corfu menu

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,6 +40,10 @@ lsp-bridge使用Python多线程技术在Emacs和LSP服务器之间构建高速�
 (require 'company-box)
 (company-box-mode 1)
 (global-lsp-bridge-mode)
+
+;; Xref 配置：
+(add-hook 'lsp-bridge-mode-hook (lambda ()
+  (add-hook 'xref-backend-functions #'lsp-bridge-xref-backend nil t)))
 ```
 
 ## 命令列表
@@ -54,6 +58,13 @@ lsp-bridge使用Python多线程技术在Emacs和LSP服务器之间构建高速�
 * lsp-bridge-rename: 重命名
 * lsp-bridge-show-signature-help-in-minibuffer: 在minibuffer显示参数信息
 * lsp-bridge-restart-process: 重启lsp-bridge进程 (一般只有开发者才需要这个功能)
+
+
+配置 Xref 后，可以使用 Xref 命令查找函数定义和跳转，当前支持命令如下：
+
+* xref-find-definitions: 跳转到定义的位置
+* xref-go-back: 返回 Xref 跳转之前的位置
+* xref-go-forward: 跳转到调用 `xref-go-back` 命令之前的位置
 
 ## 自定义语言服务器配置
 lsp-bridge每种语言的服务器配置存储在[lsp-bridge/langserver](https://github.com/manateelazycat/lsp-bridge/tree/master/langserver).

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -80,6 +80,7 @@
 (require 'lsp-bridge-ref)
 (require 'posframe)
 (require 'markdown-mode)
+(require 'xref)
 
 (defgroup lsp-bridge nil
   "LSP-Bridge group."
@@ -925,6 +926,21 @@ If optional MARKER, return a marker instead"
   (evil-add-command-properties #'lsp-bridge-find-def :jump t)
   (evil-add-command-properties #'lsp-bridge-find-references :jump t)
   (evil-add-command-properties #'lsp-bridge-find-impl :jump t))
+
+
+;;;###autoload
+(defun lsp-bridge-xref-backend ()
+  "LSP Bridge backend for Xref."
+  'lsp-bridge)
+
+(cl-defmethod xref-backend-identifier-at-point ((_backend (eql lsp-bridge)))
+  (lsp-bridge-find-def))
+
+(cl-defmethod xref-backend-definitions ((_backend (eql lsp-bridge)) _)
+  (lsp-bridge-find-def))
+
+(cl-defmethod xref-backend-references ((_backend (eql lsp-bridge)) _)
+  (lsp-bridge-find-def))
 
 (provide 'lsp-bridge)
 


### PR DESCRIPTION
implement xref backend, so that users can use xref commands to find def and jump around.

commands on README work perfectly.

known problems:
- `xref-find-definitions-other-windows` jump in the origin window instead of the other one
