### PR TITLE
gopls支持snippet 

### DIFF
--- a/langserver/gopls.json
+++ b/langserver/gopls.json
@@ -2,5 +2,23 @@
   "name": "gopls",
   "languageId": "go",
   "command": ["gopls", "-remote=auto"],
-  "settings": {}
+  "settings":{
+    "gopls": {
+      "usePlaceholders": true,
+      "completeUnimported": true,
+      "staticcheck": false,
+      "allowImplicitNetworkAccess": true,
+      "experimentalWorkspaceModule": true,
+      "allowModfileModifications": true
+    }
+  },
+  "capabilities": {
+    "textDocument": {
+      "completion": {
+        "completionItem": {
+          "snippetSupport": true
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
有个问题， 现在对 client 端是否具备某种`capabilities`  是写在langserver 下的json 文件中的， 比如现在添加的gopls中的
``` 
 "capabilities": {
    "textDocument": {
      "completion": {
        "completionItem": {
          "snippetSupport": true
        }
      }
    }
  }
```
但我认为这应该是lsp-bridge 的能力， 不是server的能力。 感觉应该写死在`el`中（或为lsp 的client 端也出一个json 文件统一存在。，而不是让每个server 配置文件中写一份。
