### PR TITLE
支持像eglot 一样在elisp 端配置client-capabilities，并全局支持snippet ，并gopls server端配置支持snippet 等

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -317,7 +317,14 @@ class LspServer:
         }
 
     def handle_workspace_configuration_request(self, name, request_id, params):
-        self.sender.send_response(request_id, [])
+        # name= "workspace/configuration"
+        # params ="{’items’: [{’scopeUri’: ’file:///repos/lsp-bridge’, ’section’: ’gopls’}]}"
+        items = []
+        for p in params["items"]:
+            section = p.get("section", self.server_info["name"])
+            settings = self.server_info.get("settings", {})
+            items.append(settings.get(section, {}))
+        self.sender.send_response(request_id, items)
 
     def handle_recv_message(self, message: dict):
         if "error" in message:

--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import copy
 import json
 import os
 import queue
@@ -39,6 +40,159 @@ if TYPE_CHECKING:
 from core.utils import *
 
 DEFAULT_BUFFER_SIZE = 100000000  # we need make buffer size big enough, avoid pipe hang by big data response from LSP server
+
+
+LSP_CLIENT_INFO = {
+    "capabilities": {
+        "workspace": {
+            "applyEdit": False,
+            "executeCommand": {
+                "dynamicRegistration": False
+            },
+            "workspaceEdit": {
+                "documentChanges": False
+            },
+            "didChangeWatchedFiles": {
+                "dynamicRegistration": False
+            },
+            "symbol": {
+                "dynamicRegistration": False
+            },
+            "configuration": True,
+            "workspaceFolders": False
+        },
+        "textDocument": {
+            "synchronization": {
+                "dynamicRegistration": False,
+                "willSave": False,
+                "willSaveWaitUntil": False,
+                "didSave": True
+            },
+            "completion": {
+                "dynamicRegistration": False,
+                "completionItem": {
+                    "snippetSupport": True,
+                    "deprecatedSupport": False,
+                    "tagSupport": {
+                        "valueSet": [
+                            1
+                        ]
+                    }
+                },
+                "contextSupport": True
+            },
+            "hover": {
+                "dynamicRegistration": False,
+                "contentFormat": [
+                    "markdown",
+                    "plaintext"
+                ]
+            },
+            "signatureHelp": {
+                "dynamicRegistration": False,
+                "signatureInformation": {
+                    "parameterInformation": {
+                        "labelOffsetSupport": False
+                    },
+                    "activeParameterSupport": False
+                }
+            },
+            "references": {
+                "dynamicRegistration": False
+            },
+            "definition": {
+                "dynamicRegistration": False,
+                "linkSupport": True
+            },
+            "declaration": {
+                "dynamicRegistration": False,
+                "linkSupport": True
+            },
+            "implementation": {
+                "dynamicRegistration": False,
+                "linkSupport": True
+            },
+            "typeDefinition": {
+                "dynamicRegistration": False,
+                "linkSupport": True
+            },
+            "documentSymbol": {
+                "dynamicRegistration": False,
+                "hierarchicalDocumentSymbolSupport": False,
+                "symbolKind": {
+                    "valueSet": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25,
+                        26
+                    ]
+                }
+            },
+            "documentHighlight": {
+                "dynamicRegistration": False
+            },
+            "codeAction": {
+                "dynamicRegistration": False,
+                "codeActionLiteralSupport": {
+                    "codeActionKind": {
+                        "valueSet": [
+                            "quickfix",
+                            "refactor",
+                            "refactor.extract",
+                            "refactor.inline",
+                            "refactor.rewrite",
+                            "source",
+                            "source.organizeImports"
+                        ]
+                    }
+                },
+                "isPreferredSupport": False
+            },
+            "formatting": {
+                "dynamicRegistration": False
+            },
+            "rangeFormatting": {
+                "dynamicRegistration": False
+            },
+            "rename": {
+                "dynamicRegistration": False
+            },
+            "publishDiagnostics": {
+                "relatedInformation": False,
+                "codeDescriptionSupport": False,
+                "tagSupport": {
+                    "valueSet": [
+                        1,
+                        2
+                    ]
+                }
+            }
+        },
+        "experimental": {}
+    }
+}
 
 
 class LspServerSender(Thread):
@@ -175,6 +329,7 @@ class LspServer:
         self.message_queue = message_queue
         self.project_path = project_path
         self.server_info = server_info
+        self.client_info = copy.deepcopy(LSP_CLIENT_INFO)
         self.initialize_id = generate_request_id()
         self.server_name = server_name
         self.request_dict: Dict[int, Handler] = dict()
@@ -185,6 +340,12 @@ class LspServer:
 
         # Start LSP server.
         self.p = subprocess.Popen(self.server_info["command"], bufsize=DEFAULT_BUFFER_SIZE, stdin=PIPE, stdout=PIPE, stderr=stderr)
+
+        is_snippet_support = get_emacs_func_result("is-snippet-support") # "true" or "false"
+        if not is_snippet_support:
+            self.client_info["capabilities"]["textDocument"]["completion"]["completionItem"]["snippetSupport"]=False
+        else:
+            self.client_info["capabilities"]["textDocument"]["completion"]["completionItem"]["snippetSupport"]=True
 
         # Notify user server is start.
         message_emacs("Start LSP server ({}) for {}...".format(self.server_info["name"], self.root_path))
@@ -236,7 +397,7 @@ class LspServer:
                 "version": get_emacs_version()
             },
             "rootUri": path_to_uri(self.project_path),
-            "capabilities": self.server_info.get("capabilities", {}),
+            "capabilities": self.client_info["capabilities"],
             "initializationOptions": self.server_info.get("initializationOptions", {})
         }, self.initialize_id, init=True)
 

--- a/langserver/dart-analysis-server.json
+++ b/langserver/dart-analysis-server.json
@@ -2,14 +2,5 @@
   "name": "dart-analysis-server",
   "languageId": "dart",
   "command": ["dart", "language-server", "--client-id", "emacs.lsp-bridge"],
-  "settings": {},
-  "capabilities": {
-    "textDocument": {
-      "completion": {
-        "completionItem": {
-          "snippetSupport": true
-        }
-      }
-    }
-  }
+  "settings": {}
 }

--- a/langserver/gopls.json
+++ b/langserver/gopls.json
@@ -2,5 +2,10 @@
   "name": "gopls",
   "languageId": "go",
   "command": ["gopls", "-remote=auto"],
-  "settings": {}
+  "settings":{
+    "gopls": {
+      "usePlaceholders": true,
+      "completeUnimported": true
+    }
+  }
 }

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -176,6 +176,7 @@ Start discarding off end if gets this big."
                (lsp-bridge-epc-define-method mngr 'get-emacs-vars 'lsp-bridge--get-emacs-vars-func)
                (lsp-bridge-epc-define-method mngr 'get-lang-server 'lsp-bridge--get-lang-server-func)
                (lsp-bridge-epc-define-method mngr 'get-emacs-version 'emacs-version)
+               (lsp-bridge-epc-define-method mngr 'is-snippet-support 'lsp-bridge--snippet-expansion-fn)
                ))))
     (if lsp-bridge-server
         (setq lsp-bridge-server-port (process-contact lsp-bridge-server :service))


### PR DESCRIPTION
 client-capabilities 应该是client 端的能力， 而不应该在 langserver的配置文件中进行配置。
lsp-bridge--client-capabilities 是在 eglot-client-capabilities基础上微调，并以注释的形式保留eglot 大部分楝

`eglot-client-capabilities` 的函数支持传递一个server参数，以便根据不同的server ,调整client 端的capabilities,
lsp-bridge--client-capabilities的实现 目前server 传的是nil （不清楚lsp-bridge有没有相应的server信息)
不过`eglot-client-capabilities` 仅在对tramp的支持上用到了server这个参数,短期不打算支持capabilities的话，影响不大。

后续可以有序的打开各个选项。
目前只配置了 `snippetSupport`的支持。其他选项不了解，作者可后续酌情打开相应的注释。

2. dart-analysis-server.json 中有 snippetSupport相关支持， 现给去掉了。
3. gopls server 端 配置snippet 相关支持，及其他一些选项。


gopls 的一些配置 在
 https://github.com/golang/tools/blob/master/gopls/doc/emacs.md  与
https://github.com/golang/tools/blob/master/gopls/doc/settings.md
 
eglot 的cllient-capabilities 

 ```
{
  "workspace": {
    "applyEdit": true,
    "executeCommand": {
      "dynamicRegistration": false
    },
    "workspaceEdit": {
      "documentChanges": true
    },
    "didChangeWatchedFiles": {
      "dynamicRegistration": false
    },
    "symbol": {
      "dynamicRegistration": false
    },
    "configuration": true,
    "workspaceFolders": true
  },
  "textDocument": {
    "synchronization": {
      "dynamicRegistration": false,
      "willSave": true,
      "willSaveWaitUntil": true,
      "didSave": true
    },
    "completion": {
      "dynamicRegistration": false,
      "completionItem": {
        "snippetSupport": true,
        "deprecatedSupport": true,
        "tagSupport": {
          "valueSet": [
            1
          ]
        }
      },
      "contextSupport": true
    },
    "hover": {
      "dynamicRegistration": false,
      "contentFormat": [
        "markdown",
        "plaintext"
      ]
    },
    "signatureHelp": {
      "dynamicRegistration": false,
      "signatureInformation": {
        "parameterInformation": {
          "labelOffsetSupport": true
        },
        "activeParameterSupport": true
      }
    },
    "references": {
      "dynamicRegistration": false
    },
    "definition": {
      "dynamicRegistration": false,
      "linkSupport": true
    },
    "declaration": {
      "dynamicRegistration": false,
      "linkSupport": true
    },
    "implementation": {
      "dynamicRegistration": false,
      "linkSupport": true
    },
    "typeDefinition": {
      "dynamicRegistration": false,
      "linkSupport": true
    },
    "documentSymbol": {
      "dynamicRegistration": false,
      "hierarchicalDocumentSymbolSupport": true,
      "symbolKind": {
        "valueSet": [
          1,
          2,
          3,
          4,
          5,
          6,
          7,
          8,
          9,
          10,
          11,
          12,
          13,
          14,
          15,
          16,
          17,
          18,
          19,
          20,
          21,
          22,
          23,
          24,
          25,
          26
        ]
      }
    },
    "documentHighlight": {
      "dynamicRegistration": false
    },
    "codeAction": {
      "dynamicRegistration": false,
      "codeActionLiteralSupport": {
        "codeActionKind": {
          "valueSet": [
            "quickfix",
            "refactor",
            "refactor.extract",
            "refactor.inline",
            "refactor.rewrite",
            "source",
            "source.organizeImports"
          ]
        }
      },
      "isPreferredSupport": true
    },
    "formatting": {
      "dynamicRegistration": false
    },
    "rangeFormatting": {
      "dynamicRegistration": false
    },
    "rename": {
      "dynamicRegistration": false
    },
    "publishDiagnostics": {
      "relatedInformation": false,
      "codeDescriptionSupport": false,
      "tagSupport": {
        "valueSet": [
          1,
          2
        ]
      }
    }
  },
  "experimental": {}
}

```