### PR TITLE
pyright settings 配置更新。

### DIFF
--- a/langserver/pyright.json
+++ b/langserver/pyright.json
@@ -3,7 +3,7 @@
   "languageId": "python",
   "command": ["pyright-langserver", "--stdio"],
   "settings": {
-    "analysis": {
+    "python.analysis": {
       "autoImportCompletions": true,
       "typeshedPaths": [],
       "stubPath": "",


### PR DESCRIPTION
pyright 读取配置好像是分段的，之前那些选项都可能没被读到。
参见https://github.com/microsoft/pyright/blob/67ee16bef49e02403372e3350a07f7da8ab07115/packages/pyright-internal/src/server.ts#L113
在  emacs-china 对应帖子里面做了验证。这样改了之后 pandas 等补全都有效了。