### PR TITLE
fix disable and reenable corfu auto completion

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -967,6 +967,8 @@ If optional MARKER, return a marker instead"
 
        (setq-local corfu-auto-prefix 0)
        (setq-local corfu-auto nil)
+       (remove-hook 'post-command-hook #'corfu--auto-post-command 'local)
+
        ;; Add fuzzy match.
        (when (functionp 'lsp-bridge-orderless-setup)
          (lsp-bridge-orderless-setup))))
@@ -977,6 +979,15 @@ If optional MARKER, return a marker instead"
 
 (defun lsp-bridge--disable ()
   "Disable LSP Bridge mode."
+  (cl-case lsp-bridge-completion-provider
+    (company
+     (kill-local-variable 'company-minimum-prefix-length)
+     (kill-local-variable 'company-idle-delay))
+    (corfu
+     (kill-local-variable 'corfu-auto-prefix)
+     (kill-local-variable 'corfu-auto)
+     (and corfu-auto (add-hook 'post-command-hook #'corfu--auto-post-command nil 'local))))
+
   (dolist (hook lsp-bridge--internal-hooks)
     (remove-hook (car hook) (cdr hook) t)))
 


### PR DESCRIPTION
need remove corfu--auto-post-command from post-command-hook if manually enable lsp-bridge-mode
and corfu auto completion already enabled.