### PR TITLE
No need to remove spaces in strings thanks to sexpdata

### DIFF
--- a/core/handler/completion.py
+++ b/core/handler/completion.py
@@ -38,13 +38,13 @@ class Completion(Handler):
         if response is not None:
             for item in response["items"] if "items" in response else response:
                 kind = KIND_MAP[item.get("kind", 0)]
-                
+
                 candidate = {
                     "label": item["label"],
                     "tags": item.get("tags", []),
                     "insertText": item.get('insertText', None),
                     "kind": kind,
-                    "annotation": (item.get("detail") or kind).replace(" ", ""),
+                    "annotation": item.get("detail", kind),
                     "insertTextFormat": item.get("insertTextFormat", ''),
                     "textEdit": item.get("textEdit", None)
                 }


### PR DESCRIPTION
annotation 中删除空格是历史遗留问题，最初与 emacs 通讯需要用空格区分参数。改用 sexpdata 之后不需要这么做了