### PR TITLE
adjust autoload statement

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -938,7 +938,6 @@ If optional MARKER, return a marker instead"
               (string-equal (buffer-name) "*Messages*"))
     (setq lsp-bridge--last-buffer (current-buffer))))
 
-;;;###autoload
 (add-hook 'post-command-hook 'lsp-bridge-monitor-window-buffer-change)
 
 (defconst lsp-bridge--internal-hooks
@@ -951,6 +950,7 @@ If optional MARKER, return a marker instead"
 
 (defvar lsp-bridge-mode-map (make-sparse-keymap))
 
+;;;###autoload
 (define-minor-mode lsp-bridge-mode
   "LSP Bridge mode."
   :keymap lsp-bridge-mode-map
@@ -1012,6 +1012,7 @@ If optional MARKER, return a marker instead"
   (lsp-bridge--with-file-buffer filepath
     (lsp-bridge--disable)))
 
+;;;###autoload
 (defun global-lsp-bridge-mode ()
   (interactive)
 


### PR DESCRIPTION
移除 **(add-hook 'post-command-hook 'lsp-bridge-monitor-window-buffer-change)** 的 autoload 标签，lsp-bridge-monitor-window-buffer-change 并不是 autoload 函数，如果加载生成的 autoload 文件就会报找不到这个函数的错误，感觉这行代码也不需要  autoload 。