### PR TITLE
fix additional character after completion

### DIFF
--- a/core/handler/completion.py
+++ b/core/handler/completion.py
@@ -22,13 +22,17 @@ class Completion(Handler):
     method = "textDocument/completion"
     cancel_on_change = True
 
+    def __init__(self, file_action: "FileAction"):
+        super().__init__(file_action)
+        self.position = None
+        
     def process_request(self, position, char) -> dict:
         if char in self.file_action.lsp_server.completion_trigger_characters:
             context = dict(triggerCharacter=char,
                            triggerKind=CompletionTriggerKind.TriggerCharacter.value)
         else:
             context = dict(triggerKind=CompletionTriggerKind.Invoked.value)
-
+        self.position = position
         return dict(position=position, context=context)
 
     def process_response(self, response: dict) -> None:
@@ -40,6 +44,7 @@ class Completion(Handler):
                 kind = KIND_MAP[item.get("kind", 0)]
 
                 candidate = {
+                    "position": self.position,
                     "label": item["label"],
                     "tags": item.get("tags", []),
                     "insertText": item.get('insertText', None),

--- a/core/handler/completion.py
+++ b/core/handler/completion.py
@@ -63,7 +63,7 @@ class Completion(Handler):
             eval_in_emacs("lsp-bridge-record-completion-items",
                         self.file_action.filepath,
                         completion_common_string,
-                        self.position,
                         completion_candidates,
+                        self.position,
                         self.file_action.lsp_server.server_info["name"],
                         self.file_action.lsp_server.completion_trigger_characters)

--- a/core/handler/completion.py
+++ b/core/handler/completion.py
@@ -22,10 +22,6 @@ class Completion(Handler):
     method = "textDocument/completion"
     cancel_on_change = True
 
-    def __init__(self, file_action: "FileAction"):
-        super().__init__(file_action)
-        self.position = None
-        
     def process_request(self, position, char) -> dict:
         if char in self.file_action.lsp_server.completion_trigger_characters:
             context = dict(triggerCharacter=char,
@@ -44,7 +40,6 @@ class Completion(Handler):
                 kind = KIND_MAP[item.get("kind", 0)]
 
                 candidate = {
-                    "position": self.position,
                     "label": item["label"],
                     "tags": item.get("tags", []),
                     "insertText": item.get('insertText', None),
@@ -68,6 +63,7 @@ class Completion(Handler):
             eval_in_emacs("lsp-bridge-record-completion-items",
                         self.file_action.filepath,
                         completion_common_string,
+                        self.position,
                         completion_candidates,
                         self.file_action.lsp_server.server_info["name"],
                         self.file_action.lsp_server.completion_trigger_characters)

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -485,6 +485,7 @@ Auto completion is only performed if the tick did not change."
 (defvar-local lsp-bridge-completion-trigger-characters nil)
 (defvar-local lsp-bridge-completion-prefix nil)
 (defvar-local lsp-bridge-completion-common nil)
+(defvar-local lsp-bridge-completion-position nil)
 (defvar-local lsp-bridge-filepath "")
 (defvar-local lsp-bridge-prohibit-completion nil)
 (defvar-local lsp-bridge-current-tick nil)
@@ -518,10 +519,11 @@ Auto completion is only performed if the tick did not change."
            (string-empty-p (format "%s" (car list))))
       (and (eq (length list) 0))))
 
-(defun lsp-bridge-record-completion-items (filepath common items server-name completion-trigger-characters)
+(defun lsp-bridge-record-completion-items (filepath common position items server-name completion-trigger-characters)
   (lsp-bridge--with-file-buffer filepath
     ;; Save completion items.
     (setq-local lsp-bridge-completion-common common)
+    (setq-local lsp-bridge-completion-position position)
     (setq-local lsp-bridge-completion-server-name server-name)
     (setq-local lsp-bridge-completion-trigger-characters completion-trigger-characters)
 
@@ -652,14 +654,13 @@ Auto completion is only performed if the tick did not change."
                                              nil))
                       (kind (plist-get candidate-info :kind))
                       (snippet-fn (and (or (eql insert-text-format 2) (string= kind "Snippet")) (lsp-bridge--snippet-expansion-fn)))
-                      (position-pos (lsp-bridge--lsp-position-to-point
-                                     (plist-get candidate-info :position)))
+                      (position-pos (lsp-bridge--lsp-position-to-point lsp-bridge-completion-position))
                       (delete-start-pos (if text-edit
                                             (lsp-bridge--lsp-position-to-point (plist-get (plist-get text-edit :range) :start))
                                           bounds-start))
                       (range-end-pos (if text-edit
-                                            (lsp-bridge--lsp-position-to-point (plist-get (plist-get text-edit :range) :end))
-                                          position-pos))
+                                         (lsp-bridge--lsp-position-to-point (plist-get (plist-get text-edit :range) :end))
+                                       position-pos))
                       (delete-end-pos (+ (point) (- range-end-pos position-pos)))
                       (insert-candidate (or new-text insert-text label)))
 

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -519,7 +519,7 @@ Auto completion is only performed if the tick did not change."
            (string-empty-p (format "%s" (car list))))
       (and (eq (length list) 0))))
 
-(defun lsp-bridge-record-completion-items (filepath common position items server-name completion-trigger-characters)
+(defun lsp-bridge-record-completion-items (filepath common items position server-name completion-trigger-characters)
   (lsp-bridge--with-file-buffer filepath
     ;; Save completion items.
     (setq-local lsp-bridge-completion-common common)
@@ -654,14 +654,14 @@ Auto completion is only performed if the tick did not change."
                                              nil))
                       (kind (plist-get candidate-info :kind))
                       (snippet-fn (and (or (eql insert-text-format 2) (string= kind "Snippet")) (lsp-bridge--snippet-expansion-fn)))
-                      (position-pos (lsp-bridge--lsp-position-to-point lsp-bridge-completion-position))
+                      (completion-start-pos (lsp-bridge--lsp-position-to-point lsp-bridge-completion-position))
                       (delete-start-pos (if text-edit
                                             (lsp-bridge--lsp-position-to-point (plist-get (plist-get text-edit :range) :start))
                                           bounds-start))
                       (range-end-pos (if text-edit
                                          (lsp-bridge--lsp-position-to-point (plist-get (plist-get text-edit :range) :end))
-                                       position-pos))
-                      (delete-end-pos (+ (point) (- range-end-pos position-pos)))
+                                       completion-start-pos))
+                      (delete-end-pos (+ (point) (- range-end-pos completion-start-pos)))
                       (insert-candidate (or new-text insert-text label)))
 
                  ;; Insert candidate or expand snippet.

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -652,10 +652,15 @@ Auto completion is only performed if the tick did not change."
                                              nil))
                       (kind (plist-get candidate-info :kind))
                       (snippet-fn (and (or (eql insert-text-format 2) (string= kind "Snippet")) (lsp-bridge--snippet-expansion-fn)))
+                      (position-pos (lsp-bridge--lsp-position-to-point
+                                     (plist-get candidate-info :position)))
                       (delete-start-pos (if text-edit
                                             (lsp-bridge--lsp-position-to-point (plist-get (plist-get text-edit :range) :start))
                                           bounds-start))
-                      (delete-end-pos (point))
+                      (range-end-pos (if text-edit
+                                            (lsp-bridge--lsp-position-to-point (plist-get (plist-get text-edit :range) :end))
+                                          position-pos))
+                      (delete-end-pos (+ (point) (- range-end-pos position-pos)))
                       (insert-candidate (or new-text insert-text label)))
 
                  ;; Insert candidate or expand snippet.


### PR DESCRIPTION
解决 c 里面 include <|> 补全会多出一个 > 的问题。
原理：如果补全返回的 textEdit 中 range end 比当前补全时的 position 更大，则表示需要删除补全之后的某些字符，因此在补全的 :exit-function 中，将其加到 delete-end-pos 中。测试过 c / python, 暂未发现副作用。