### PR TITLE
修正 auto-import 失效

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -700,8 +700,8 @@ Doubles as an indicator of snippet support."
                     (newText (plist-get edit :newText)))
                (cons newText
                      (cons
-                      (lsp-bridge--lsp-position-to-point (plist-get range :start) markers)
-                      (lsp-bridge--lsp-position-to-point (plist-get range :end) markers)
+                      (lsp-bridge--lsp-position-to-point (plist-get range :start) 'markers)
+                      (lsp-bridge--lsp-position-to-point (plist-get range :end) 'markers)
                       ))))
            (reverse edits)))
     (undo-amalgamate-change-group change-group)))


### PR DESCRIPTION
auto-import 之前会报错 void-variable markers, 参考 eglot 处理，修改后可以了。