### PR TITLE
Fix multiple candidates in one line when renaming

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -881,7 +881,7 @@ If optional MARKER, return a marker instead"
 (defun lsp-bridge-rename-file (filepath edits)
   (find-file-noselect filepath)
   (lsp-bridge--with-file-buffer filepath
-    (dolist (edit edits)
+    (dolist (edit (reverse edits))
       (let* ((bound-start (nth 0 edit))
              (bound-end (nth 1 edit))
              (new-text (nth 2 edit))


### PR DESCRIPTION
Issue:
As below, I am trying to rename `a` to `abc` with double `a` in the same line.
<img width="179" alt="image" src="https://user-images.githubusercontent.com/3063690/172003358-3e7cf564-8e2e-4061-9243-81b438cc8468.png">
And it turns to be something like below as the ranges of two candidates overlap.
<img width="208" alt="image" src="https://user-images.githubusercontent.com/3063690/172003387-9a476973-3c36-4824-ac47-d100a7cf9561.png">

Solution:
A simple solution is to apply the edit from the bottom to the top by reversing `edits`. It works though I am not sure whether there is side effect.