### PR TITLE
fix warning

### DIFF
--- a/acm/acm.el
+++ b/acm/acm.el
@@ -636,8 +636,8 @@ influence of C1 on the result."
 
 (defun acm-menu-max-length ()
   (cl-reduce #'max
-             (mapcar '(lambda (v)
-                        (string-width (format "%s %s" (plist-get v :display-label) (plist-get v :annotation))))
+             (mapcar #'(lambda (v)
+                         (string-width (format "%s %s" (plist-get v :display-label) (plist-get v :annotation))))
                      acm-menu-candidates)))
 
 (defvar acm-fetch-candidate-doc-function nil)
@@ -712,7 +712,7 @@ influence of C1 on the result."
             (pcase backend
               ("lsp" (plist-get candidate :documentation))
               ("elisp" (documentation (intern (plist-get candidate :label))))
-              (t ""))))
+              (_ ""))))
       (when (and candidate-doc
                  (not (string-equal candidate-doc "")))
 


### PR DESCRIPTION
emacs-plus 28.1在macos下使用straight包管理启动时会有warning

<img width="1141" alt="image" src="https://user-images.githubusercontent.com/5388526/172079227-04b14ebe-063d-4e39-8d60-7f731fda5828.png">
