### PR TITLE
Fix completion_item documentation is markdown (dict).

### DIFF
--- a/core/fileaction.py
+++ b/core/fileaction.py
@@ -143,6 +143,10 @@ class FileAction:
                     
     def completion_item_update(self, item_key, documentation, additional_text_edits):
         if documentation != "" or additional_text_edits != "":
+            if type(documentation) == dict:
+                if "kind" in documentation:
+                    if documentation["kind"] == "markdown":
+                        documentation = documentation["value"]
             eval_in_emacs("lsp-bridge-update-completion-item-info",
                           {
                               "filepath": self.filepath,


### PR DESCRIPTION
Fix elixirLS 's completion_item documentation is a markdown dict.

![image](https://user-images.githubusercontent.com/13914416/172210286-8662d9e5-f9c9-4143-b64e-96f1a0b28c33.png)

