### PR TITLE
add simple orderless support

### DIFF
--- a/acm/acm-backend-tempel.el
+++ b/acm/acm-backend-tempel.el
@@ -36,7 +36,7 @@
   (let ((snippet
          (alist-get (intern-soft (plist-get candidate :label)) 
                     (tempel--templates))))            
-    (mapconcat (lambda (s) (format "%s" s)) snippet " ")))
+    (mapconcat #'tempel--print-element snippet " ")))
     
 (provide 'acm-backend-tempel)
 

--- a/acm/acm.el
+++ b/acm/acm.el
@@ -132,6 +132,16 @@ Default is 1 second."
   "Insert index of snippet candidate of menu."
   :type 'integer)
 
+(defcustom acm-candidate-match-function 'regexp-quote
+  "acm candidate match function."
+  :type '(choice (const regexp-quote)
+                 (const orderless-literal) 
+                 (const orderless-prefixes)
+                 (const orderless-flex) 
+                 (const orderless-regexp)
+                 (const orderless-initialism)))
+
+
 (defvar acm-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map [remap next-line] #'acm-select-next)
@@ -384,7 +394,8 @@ influence of C1 on the result."
 
 (defun acm-candidate-fuzzy-search (keyword candiate)
   "Fuzzy search candiate."
-  (string-match-p (regexp-quote (downcase keyword)) (downcase candiate)))
+  (string-match-p (funcall acm-candidate-match-function (downcase keyword)) 
+                  (downcase candiate)))
 
 (defun acm-candidate-sort-by-prefix (keyword candiates)
   "Priority display of the candiates of the prefix matching."


### PR DESCRIPTION
增加了最简单的 orderless 支持。可以自由选择样式。因为需要用户显示设置相关函数，所以也就没加依赖，默认用户已经安装并配置过 orderless 才会有这个需求。