### PR TITLE
Update signature_help.py

### DIFF
--- a/core/handler/signature_help.py
+++ b/core/handler/signature_help.py
@@ -12,6 +12,7 @@ class SignatureHelp(Handler):
 
     def process_response(self, response: dict) -> None:
         if response is not None:
-            eval_in_emacs("lsp-bridge-signature-help-update", 
-                          list(map(lambda p: p["label"].split(":")[0], response["signatures"][response["activeSignature"]]["parameters"])),
-                          response["activeParameter"])
+            if "parameters" in response["signatures"][0]:
+                eval_in_emacs("lsp-bridge-signature-help-update", 
+                              list(map(lambda p: p["label"].split(":")[0], response["signatures"][response.get("activeSignature", 0)]["parameters"])),
+                              response.get("activeParameter", 0))


### PR DESCRIPTION
fix #207

修复 lsp server  signatureHelp 响应不包含 activeSignature、activeParameter 或 parameters 的情况。