### PR TITLE
Fixed Windows subprocess.Popen Fail BUG

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -187,7 +187,12 @@ class LspServer:
         self.rename_prepare_provider = False
 
         # Start LSP server.
-        self.p = subprocess.Popen(self.server_info["command"], bufsize=DEFAULT_BUFFER_SIZE, stdin=PIPE, stdout=PIPE, stderr=stderr)
+        try:
+            self.p = subprocess.Popen(self.server_info["command"], bufsize=DEFAULT_BUFFER_SIZE, stdin=PIPE, stdout=PIPE, stderr=stderr)
+        except FileNotFoundError:
+            self.p = subprocess.Popen(self.server_info["command"], bufsize=DEFAULT_BUFFER_SIZE, stdin=PIPE, stdout=PIPE, stderr=stderr, shell=True)
+        except Exception as e:
+            print('Err type : {} {}'.format(type(e), e))
 
         # Notify user server is start.
         message_emacs("Start LSP server ({}) for {}...".format(self.server_info["name"], self.root_path))


### PR DESCRIPTION
Fixed the following error, tested on MAC without problems, Linux should also have no problems.

`Exception in thread Thread-2:
Traceback (most recent call last):
  File "e:\Anaconda3\lib\threading.py", line 932, in _bootstrap_inner
    self.run()
  File "e:\Anaconda3\lib\threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "~/.doom.d/elisp/lsp-bridge/lsp_bridge.py", line 104, in event_dispatcher
    getattr(self, func_name)(*func_args)
  File "~/.doom.d/elisp/lsp-bridge/lsp_bridge.py", line 215, in _do
    open_file_success = self._open_file(filepath)  # _do is called inside event_loop, so we can block here.
  File "~/.doom.d/elisp/lsp-bridge/lsp_bridge.py", line 178, in _open_file
    self.lsp_server_dict[lsp_server_name] = LspServer(
  File "~\.doom.d\elisp\lsp-bridge\core\lspserver.py", line 190, in __init__
    self.p = subprocess.Popen(self.server_info["command"], bufsize=DEFAULT_BUFFER_SIZE, stdin=PIPE, stdout=PIPE, stderr=stderr)
  File "e:\Anaconda3\lib\subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "e:\Anaconda3\lib\subprocess.py", line 1307, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
FileNotFoundError: [WinError 2] 系统找不到指定的文件。`