### PR TITLE
sort elisp candidates

### DIFF
--- a/acm/acm-backend-elisp.el
+++ b/acm/acm-backend-elisp.el
@@ -88,13 +88,20 @@
   "Minimum length of elisp symbol."
   :type 'integer)
 
+(defun acm-backend-elisp-sort-predicate (x y)
+  "Sorting predicate which compares X and Y."
+  (or (< (length x) (length y))
+      (and (= (length x) (length y))
+           (string< x y))))
+
 (defun acm-backend-elisp-candidates (keyword)
   (let* ((candidates (list)))
     (when (and (or (derived-mode-p 'emacs-lisp-mode)
                    (derived-mode-p 'inferior-emacs-lisp-mode)
                    (derived-mode-p 'lisp-interaction-mode))
                (>= (length keyword) acm-backend-elisp-min-length))
-      (let ((elisp-symbols (sort (all-completions keyword obarray) 'string<)))
+      (let ((elisp-symbols (sort (all-completions keyword obarray) 
+                                 'acm-backend-elisp-sort-predicate)))
         (dolist (elisp-symbol (cl-subseq elisp-symbols 0 (min (length elisp-symbols) 10)))
           (let ((symbol-type (acm-backend-elisp-symbol-type (intern elisp-symbol))))
             (add-to-list 'candidates (list :key elisp-symbol
@@ -118,8 +125,7 @@
           ((facep symbol)
            (documentation-property symbol 'face-documentation))
           (t
-           (documentation-property symbol 'variable-documentation)
-           ))))
+           (documentation-property symbol 'variable-documentation)))))  
 
 (defun acm-backend-elisp-symbol-type (symbol)
   (cond ((functionp symbol)


### PR DESCRIPTION
这个比较函数总是会把匹配，最短的放前面。之前 “string<" 会把很长的放前面。