### PR TITLE
fix typo

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1351,7 +1351,7 @@ Auto completion is only performed if the tick did not change."
 ;; https://tecosaur.github.io/emacs-config/config.html#lsp-support-src
 (cl-defmacro lsp-org-babel-enable (lang)
   "Support LANG in org source code block."
-  (cl-check-type lang stringp)
+  (cl-check-type lang string)
   (let* ((edit-pre (intern (format "org-babel-edit-prep:%s" lang)))
          (intern-pre (intern (format "lsp--%s" (symbol-name edit-pre)))))
     `(progn


### PR DESCRIPTION
the type argument of cl-check-type should be string, not stringp