### PR TITLE
Get the change correctly

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1250,7 +1250,8 @@ Auto completion is only performed if the tick did not change."
                                menu-items)))))
 
     (pcase (plist-get action :kind)
-      ("quickfix" (lsp-bridge-code-action-quickfix (plist-get action :title) (plist-get (plist-get action :edit) :changes)))
+      ("quickfix" (lsp-bridge-code-action-quickfix (plist-get action :title)
+                                                   (plist-get (nth 0 (plist-get (plist-get action :command) :arguments)) :changes)))
       (_ (message "[LSP-BRIDGE] code action '%s' not implement yet." (plist-get action :kind))))
     ))
 


### PR DESCRIPTION
Test.java

```

public class Test {
    public static void main(String[] args) {
        List<String> list = null;
    }
}
```

`List<String>` 有问题。光标放到 List 上（或者 lsp-bridge-jump-to-next-diagnostic / lsp-bridge-jump-to-prev-diagnostic），然后 `lsp-bridge-code-action`，这时会出现好多个可选的 action，第一个是 "Import 'List' (java.util)"，选了这个之后，第一行应该会现“import java.util.List;”。

相应的 codeaction 是:
```
{
   "title":"Import 'List' (java.util)",
   "kind":"quickfix",
   "diagnostics":[
      {
         "range":{
            "start":{
               "line":3,
               "character":8
            },
            "end":{
               "line":3,
               "character":12
            }
         },
         "severity":1,
         "code":"16777218",
         "source":"Java",
         "message":"List cannot be resolved to a type",
         "data":[
            "List"
         ]
      }
   ],
   "command":{
      "title":"Import 'List' (java.util)",
      "command":"java.apply.workspaceEdit",
      "arguments":[
         {
            "changes":{
               "file:///.../Test.java":[
                  {
                     "range":{
                        "start":{
                           "line":0,
                           "character":0
                        },
                        "end":{
                           "line":1,
                           "character":0
                        }
                     },
                     "newText":"import java.util.List;\n\n"
                  }
               ]
            }
         }
      ]
   }
}
```

所以找到相应的 change 这块代码得改一下。