### PR TITLE
Add Fortran language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ You need to install the LSP server corresponding to each programming language, t
 | 26 | [groovy-language-server](https://github.com/GroovyLanguageServer/groovy-language-server) | groovy | Create a script "groovy-language-server" in PATH, with `$JAVA_HOME/bin/java -jar <path>/groovy-language-server-all.jar` |
 | 27 | [docker-language-server](https://github.com/rcjsuen/dockerfile-language-server-nodejs) | Dockerfiles | |
 | 28 | [serve-d](https://github.com/Pure-D/serve-d) | d | serve-d does not support single file mode, please init .git repository under project root at first or custom `lsp-bridge-get-project-path-by-filepath` function |
+| 29 | [fortls](https://github.com/gnikit/fortls) | Fortran | |
 
 ### Features that won't be supported
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,6 +132,7 @@ lsp-bridge每种语言的服务器配置存储在[lsp-bridge/langserver](https:/
 | 26 | [groovy-language-server](https://github.com/GroovyLanguageServer/groovy-language-server) | groovy | 在 PATH 中创建一个名为 "groovy-language-server" 的脚本, 内容为 `$JAVA_HOME/bin/java -jar <path>/groovy-language-server-all.jar` |
 | 27 | [docker-language-server](https://github.com/rcjsuen/dockerfile-language-server-nodejs) | Dockerfiles | |
 | 28 | [serve-d](https://github.com/Pure-D/serve-d) | d | serve-d 不支持单文件模式, 使用前请先在项目目录下初始 git 仓库或者自定义 `lsp-bridge-get-project-path-by-filepath` 返回项目目录 |
+| 29 | [fortls](https://github.com/gnikit/fortls) | Fortran | |
 
 ### 不会支持的特性：
 lsp-bridge的目标是实现Emacs生态中性能最快的LSP客户端, 但不是实现LSP协议最全的LSP客户端。

--- a/langserver/fortls.json
+++ b/langserver/fortls.json
@@ -1,0 +1,6 @@
+{
+  "name": "fortls",
+  "languageId": "fortran",
+  "command": ["fortls"],
+  "settings": {}
+}

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -331,7 +331,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     (zig-mode . "zls")
     (dockerfile-mode . "docker-langserver")
     (d-mode . "serve-d")
-    )
+    ((fortran-mode f90-mode) . "fortls"))
   "The lang server rule for file mode."
   :type 'cons)
 
@@ -379,7 +379,9 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     zig-mode-hook
     groovy-mode-hook
     dockerfile-mode-hook
-    d-mode-hook)
+    d-mode-hook
+    f90-mode-hook
+    fortran-mode-hook)
   "The default mode hook to enable lsp-bridge."
   :type 'list)
 


### PR DESCRIPTION
Add lsp support for `f90-mode`, `fortran-mode` for Fortran language using `fortls` language server.