### PR TITLE
Fix document hover not displaying under some language servers

### DIFF
--- a/core/handler/hover.py
+++ b/core/handler/hover.py
@@ -39,18 +39,11 @@ class Hover(Handler):
         return "\n".join(render_strings)
 
     def process_response(self, response: dict) -> None:
-        if response is None or "range" not in response or "contents" not in response:
+        if response is None or "contents" not in response or len(response["contents"]) == 0:
             message_emacs("No documentation available.")
             return
 
-        line = response["range"]["start"]["line"]
-        start_column = response["range"]["start"]["character"]
-        end_column = response["range"]["end"]["character"]
-
-        line_content = linecache.getline(self.file_action.filepath, line + 1)
-        linecache.clearcache()  # clear line cache
         contents = response["contents"]
         render_string = self.parse_hover_contents(contents, [])
 
-        eval_in_emacs("lsp-bridge-popup-documentation", "",
-                      line_content[start_column:end_column], render_string)
+        eval_in_emacs("lsp-bridge-popup-documentation", render_string)

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -981,7 +981,7 @@ Auto completion is only performed if the tick did not change."
   (let* ((theme-mode (format "%s" (frame-parameter nil 'background-mode))))
     (if (string-equal theme-mode "dark") "#191a1b" "#f0f0f0")))
 
-(defun lsp-bridge-popup-documentation (kind name value)
+(defun lsp-bridge-popup-documentation (value)
   (with-current-buffer (get-buffer-create lsp-bridge-lookup-doc-tooltip)
     (erase-buffer)
     (text-scale-set lsp-bridge-lookup-doc-tooltip-text-scale)


### PR DESCRIPTION
Some language server, for example jdtls, don't have `range` key in
textDocument/hover response. According to
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/,
t, `range` is optional in the response of `Hover Request`.