### PR TITLE
修改pythonPath 从而方便地支持python的虚拟环境

### DIFF
--- a/langserver/pyright.json
+++ b/langserver/pyright.json
@@ -18,7 +18,7 @@
       "autoSearchPaths": true,
       "extraPaths": []
     },
-    "pythonPath": "/usr/bin/python",
+    "pythonPath": "python",
     "venvPath": ""
   }
 }


### PR DESCRIPTION
将pythonPath中的内容修改为python后，pyright会指定到环境中最先找到的python，这样的话emacs用户只需在打开项目中的python文件后，开启对应的虚拟环境（e.g. pyvenv），再 M-x lsp-bridge-mode 就可以支持python虚拟环境（若已经开启lsp-bridge-mode了，就运行 M-x lsp-bridge-restart-process）
这样的修改比原先wiki中的方法主要好在：绝大多数情况下用户无需修改config中的pythonPath就可以支持虚拟环境，langserver中的配置对于用户更加透明；更简单直观；更好地支持非git submodule 的用户 （wiki中的方法需要给出lsp-bridge/langserver/pyright.json的路径）