### PR TITLE
include digestif server for latex

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ In most cases, you can customize server configuration with the following priorit
 3. ```lsp-bridge-single-lang-server-mode-list```: load server configuration based on major-mode
 
 If you are writing JavaScript code, you may need to customize multi-server configuration:
-1. ```lsp-bridge-get-multi-lang-server-by-project```: The user custom function, the input parameter is `project-path` and `file-path`, return the multi-server configuration name, you can find configuration name in the subdirectory 
+1. ```lsp-bridge-get-multi-lang-server-by-project```: The user custom function, the input parameter is `project-path` and `file-path`, return the multi-server configuration name, you can find configuration name in the subdirectory
 [lsp-bridge/multiserver](https://github.com/manateelazycat/lsp-bridge/tree/master/multiserver)
 2. ```lsp-bridge-multi-lang-server-extension-list```: Return multi-server configuration name according to the expansion of the file, for example, when opening the *.vue file, we will use the `volar` and `emmet-ls` to provide completion service
 3. ```lsp-bridge-multi-lang-server-mode-list```: Return the corresponding multi-server configuration name according to Emacs's major-mode
@@ -149,6 +149,7 @@ You need to install the LSP server corresponding to each programming language, t
 | 31 | [jedi](https://github.com/pappasam/jedi-language-server) | python | `lsp-bridge-python-lsp-server` set to `jedi` |
 | 32 | [emmet-ls](https://github.com/aca/emmet-ls) | html, js, css, sass, scss, less | |
 | 33 | [rnix-lsp](https://github.com/nix-community/rnix-lsp) | nix | |
+| 34 | [digestif](https://github.com/astoff/digestif) | latex | |
 
 
 ### Features that won't be supported

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,7 +91,7 @@ lsp-bridge每种语言的服务器配置存储在[lsp-bridge/langserver](https:/
 
 
 大多数情况， 你可以根据以下优先级顺序来自定义服务器配置：
-1. ```lsp-bridge-get-single-lang-server-by-project```: 用户自定义函数， 输入参数是 `project-path` 和 `file-path`, 返回对应的LSP服务器字符串， 可以在 `lsp-bridge-single-lang-server-mode-list` 列表中查询所有LSP服务器的名称， 默认这个函数返回 nil 
+1. ```lsp-bridge-get-single-lang-server-by-project```: 用户自定义函数， 输入参数是 `project-path` 和 `file-path`, 返回对应的LSP服务器字符串， 可以在 `lsp-bridge-single-lang-server-mode-list` 列表中查询所有LSP服务器的名称， 默认这个函数返回 nil
 2. ```lsp-bridge-single-lang-server-extension-list```: 根据文件的扩展名来返回服务器，比如打开*.wxml文件时，我们会使用 ```wxml``` LSP服务器提供补全
 3. ```lsp-bridge-single-lang-server-mode-list```: 根据Emacs的major-mode来返回对应的服务器
 
@@ -148,6 +148,7 @@ lsp-bridge每种语言的服务器配置存储在[lsp-bridge/langserver](https:/
 | 31 | [jedi](https://github.com/pappasam/jedi-language-server) | python | `lsp-bridge-python-lsp-server` 设置成 `jedi` |
 | 32 | [emmet-ls](https://github.com/aca/emmet-ls) | html, js, css, sass, scss, less | |
 | 33 | [rnix-lsp](https://github.com/nix-community/rnix-lsp) | nix | |
+| 34 | [digestif](https://github.com/astoff/digestif) | latex | |
 
 ### 不会支持的特性：
 lsp-bridge的目标是实现Emacs生态中性能最快的LSP客户端, 但不是实现LSP协议最全的LSP客户端。

--- a/langserver/digestif.json
+++ b/langserver/digestif.json
@@ -1,0 +1,6 @@
+{
+  "name": "digestif",
+  "languageId": "tex",
+  "command": ["digestif"],
+  "settings": {}
+}

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -318,6 +318,11 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
   "Default LSP server for Python language, you can choose `pyright' or `jedi'."
   :type 'string)
 
+(defcustom lsp-bridge-tex-lsp-server "texlab"
+  "Default LSP server for (la)tex, you can choose `taxlab' or `digestif'."
+  :type 'string)
+
+
 (defcustom lsp-bridge-complete-manually nil
   "Only popup completion menu when user call `lsp-bridge-popup-complete' command.")
 
@@ -345,7 +350,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     ((typescript-mode) . "typescript")
     (tuareg-mode . "ocamllsp")
     (erlang-mode . "erlang-ls")
-    ((latex-mode Tex-latex-mode texmode context-mode texinfo-mode bibtex-mode) . "texlab")
+    ((latex-mode Tex-latex-mode texmode context-mode texinfo-mode bibtex-mode) . lsp-bridge-tex-lsp-server)
     ((clojure-mode clojurec-mode clojurescript-mode clojurex-mode) . "clojure-lsp")
     ((sh-mode) . "bash-language-server")
     ((css-mode) . "vscode-css-language-server")


### PR DESCRIPTION
include support of a lightweight latex LSP [digestif](https://github.com/astoff/digestif)