### PR TITLE
Fix lsp-bridge-jdtls.el

### DIFF
--- a/lsp-bridge-jdtls.el
+++ b/lsp-bridge-jdtls.el
@@ -83,7 +83,7 @@ E.g. Use `-javaagent:/home/user/.emacs.d/plugin/lombok.jar` to add lombok suppor
   (string-equal project-path filepath))
 
 (add-hook 'java-mode-hook (lambda ()
-                            (setq-local lsp-bridge-get-lang-server-by-project 'lsp-bridge-get-jdtls-server-by-project)))
+                            (setq-local lsp-bridge-get-single-lang-server-by-project 'lsp-bridge-get-jdtls-server-by-project)))
 
 (provide 'lsp-bridge-jdtls)
 ;;; lsp-bridge-jdtls.el ends here


### PR DESCRIPTION
lsp-bridge-get-lang-server-by-project renamed to lsp-bridge-get-single-lang-server-by-project