### PR TITLE
fix: doc preview display

### DIFF
--- a/acm/acm.el
+++ b/acm/acm.el
@@ -113,7 +113,7 @@
   :type '(repeat (choice regexp symbol)))
 
 (defcustom acm-enable-doc t
-  "Popup documentation when this option is turn on."
+  "Popup documentation automatically when this option is turn on."
   :type 'boolean)
 
 (defcustom acm-enable-icon t
@@ -161,6 +161,7 @@
     (define-key map "\n" #'acm-complete)
     (define-key map "\M-h" #'acm-complete)
     (define-key map "\M-H" #'acm-insert-common)
+    (define-key map "\M-d" #'acm-doc-toggle)
     (define-key map "\M-j" #'acm-doc-scroll-up)
     (define-key map "\M-k" #'acm-doc-scroll-down)
     (define-key map "\M-l" #'acm-hide)
@@ -910,6 +911,14 @@ influence of C1 on the result."
     (when (framep acm-frame)
       (with-selected-frame acm-doc-frame
         (scroll-down-command)))))
+
+(defun acm-doc-toggle ()
+  "Toggle documentation preview for selected candidate."
+  (interactive)
+  (if (frame-visible-p acm-doc-frame)
+      (acm-doc-hide)
+    (let ((acm-enable-doc t))
+      (acm-doc-show))))
 
 (provide 'acm)
 

--- a/acm/acm.el
+++ b/acm/acm.el
@@ -920,6 +920,12 @@ influence of C1 on the result."
     (let ((acm-enable-doc t))
       (acm-doc-show))))
 
+;; Emacs 28: Do not show Acm commands with M-X
+(dolist (sym '(acm-hide acm-complete acm-select-first acm-select-last acm-select-next
+               acm-select-prev acm-insert-common acm-doc-scroll-up acm-doc-scroll-down
+               acm-complete-quick-access acm-doc-toggle))
+  (put sym 'completion-predicate #'ignore))
+
 (provide 'acm)
 
 ;;; acm.el ends here

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -170,11 +170,6 @@ Setting this to nil or 0 will turn off the indicator."
   :type 'integer
   :group 'lsp-bridge)
 
-(defcustom lsp-bridge-enable-candidate-doc-preview t
-  "Whether to enable candidate documentation."
-  :type 'boolean
-  :group 'lsp-bridge)
-
 (defcustom lsp-bridge-disable-backup t
   "Default disable backup feature, include `make-backup-files' `auto-save-default' and `create-lockfiles'."
   :type 'boolean


### PR DESCRIPTION
1. remove useless option: lsp-bridge-enable-candidate-doc-preview
2. add command acm-doc-toggle and set keymap
3. hide acm-* commands in M-x cmd