### PR TITLE
fix: acm-doc-toggle error:frame not exists when acm-enable-doc set to nil

### DIFF
--- a/acm/acm.el
+++ b/acm/acm.el
@@ -915,7 +915,7 @@ influence of C1 on the result."
 (defun acm-doc-toggle ()
   "Toggle documentation preview for selected candidate."
   (interactive)
-  (if (frame-visible-p acm-doc-frame)
+  (if (acm-frame-visible-p acm-doc-frame)
       (acm-doc-hide)
     (let ((acm-enable-doc t))
       (acm-doc-show))))


### PR DESCRIPTION
Use `acm-frame-visible-p` in `acm-doc-toggle` instead