### PR TITLE
Legacy Python lsp and GraphQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ You need to install the LSP server corresponding to each programming language, t
 | 33 | [rnix-lsp](https://github.com/nix-community/rnix-lsp) | nix | |
 | 34 | [digestif](https://github.com/astoff/digestif) | latex | `lsp-bridge-tex-lsp-server` set to `digestif` |
 | 35 | [rlanguageserver](https://github.com/REditorSupport/languageserver)       | R   | |
+| 36 | [graphql-lsp](https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-cli) | GraphQL | |
+| 37 | [microsoft-python-language-server](https://github.com/microsoft/python-language-server) | Python | legacy language server for Python2 |
 
 ### Features that won't be supported
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -153,6 +153,8 @@ lsp-bridge每种语言的服务器配置存储在[lsp-bridge/langserver](https:/
 | 33 | [rnix-lsp](https://github.com/nix-community/rnix-lsp) | nix | |
 | 34 | [digestif](https://github.com/astoff/digestif) | latex | `lsp-bridge-tex-lsp-server` 设置成 `digestif` |
 | 35 | [rlanguageserver](https://github.com/REditorSupport/languageserver)       | R   | |
+| 36 | [graphql-lsp](https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-cli) | GraphQL | |
+| 37 | [microsoft-python-language-server](https://github.com/microsoft/python-language-server) | Python | 支持Python2的lsp |
 
 ### 不会支持的特性：
 lsp-bridge的目标是实现Emacs生态中性能最快的LSP客户端, 但不是实现LSP协议最全的LSP客户端。

--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -399,11 +399,11 @@ class LspServer:
 
     def get_server_workspace_change_configuration(self):
         return {
-            "settings": self.server_info["settings"]
+            "settings": self.server_info.get("settings", {})
         }
 
     def handle_workspace_configuration_request(self, name, request_id, params):
-        settings = self.server_info.get("settings", {})            
+        settings = self.server_info.get("settings", {})
         
         # We send empty message back to server if nothing in 'settings' of server.json file.
         if len(settings) == 0:

--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -167,6 +167,8 @@ class LspServerReceiver(Thread):
                         buffer = buffer[content_length:]
                         content_length = None
                         self.emit_message(msg.decode("utf-8"))
+                if self.process.stderr:
+                    logger.info(self.process.stderr.read())
             logger.info("\n--- Lsp server exited, exit code: {}".format(self.process.returncode))
             logger.info(self.process.stdout.read())    # type: ignore
             if self.process.stderr:

--- a/langserver/graphql-lsp.json
+++ b/langserver/graphql-lsp.json
@@ -1,0 +1,6 @@
+{
+  "name": "graphql-lsp",
+  "languageId": "graphql",
+  "command": ["graphql-lsp", "server", "--method=stream"],
+  "settings": {}
+}

--- a/langserver/graphql-lsp.json
+++ b/langserver/graphql-lsp.json
@@ -2,5 +2,7 @@
   "name": "graphql-lsp",
   "languageId": "graphql",
   "command": ["graphql-lsp", "server", "--method=stream"],
-  "settings": {}
+  "settings": {
+    "graphql-config": {}
+  }
 }

--- a/langserver/python-ms.json
+++ b/langserver/python-ms.json
@@ -1,0 +1,6 @@
+{
+  "name": "python-ms",
+  "languageId": "python",
+  "command": ["Microsoft.Python.LanguageServer"],
+  "settings": {}
+}

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -310,7 +310,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
   :type 'string)
 
 (defcustom lsp-bridge-python-lsp-server "pyright"
-  "Default LSP server for Python language, you can choose `pyright' or `jedi'."
+  "Default LSP server for Python language, you can choose `pyright', `jedi', `python-ms'."
   :type 'string)
 
 (defcustom lsp-bridge-tex-lsp-server "texlab"
@@ -357,7 +357,8 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     (d-mode . "serve-d")
     ((fortran-mode f90-mode) . "fortls")
     (nix-mode . "rnix-lsp")
-    (ess-r-mode . "rlanguageserver"))
+    (ess-r-mode . "rlanguageserver")
+    (graphql-mode . "graphql-lsp"))
   "The lang server rule for file mode."
   :type 'cons)
 


### PR DESCRIPTION
This PR adds follows

1. support of GraphQL lsp (needs changes in #310)
2. support of legacy microsoft python language server for Python 2
