### PR TITLE
fix: 补全框超过了 emacs frame.

### DIFF
--- a/acm/acm.el
+++ b/acm/acm.el
@@ -728,7 +728,7 @@ influence of C1 on the result."
          (offset-x (* (window-font-width) acm-icon-width))
          (offset-y (line-pixel-height))
          (acm-frame-x (if (> (+ cursor-x acm-frame-width) emacs-width)
-                          (- cursor-x acm-frame-width)
+                          (max  (- cursor-x acm-frame-width) offset-x)
                         (max (- cursor-x offset-x) 0)))
          (acm-frame-y (if (> (+ cursor-y acm-frame-height) emacs-height)
                           (- cursor-y acm-frame-height)


### PR DESCRIPTION
当 emacs 的窗口比较狭窄时, 会出现  acm menu 的补全框, 在光标的左边, 而且 acm menu 超过了 emacs 的左边边框. 这种情况, 让补全窗口x坐标为 offset-x 应该就行了.