### PR TITLE
Stop completion after acm-complete-or-expand-yas-snippet

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -131,7 +131,7 @@ Setting this to nil or 0 will turn off the indicator."
 (defcustom lsp-bridge-completion-stop-commands
   '("undo-tree-undo" "undo-tree-redo"
     "kill-region" "delete-block-backward"
-    "python-black-buffer")
+    "python-black-buffer" "acm-complete-or-expand-yas-snippet")
   "If last command is match this option, stop popup completion ui."
   :type 'cons
   :group 'lsp-bridge)


### PR DESCRIPTION
After acm-complete-or-expand-yas-snippet, lsp-bridge still
try to run acm-complete, this will lead cursor to wrong place,
it should stop completion after acm-complete-or-expand-yas-snippet
and hit tab to next snippet field.