### PR TITLE
Bufix path complete

### DIFF
--- a/acm/acm-backend-path.el
+++ b/acm/acm-backend-path.el
@@ -90,8 +90,8 @@
 
 (defun acm-backend-path-candidates (keyword)
   (when acm-enable-path
-    (let ((candidates (list))
-          (parent-dir (ignore-errors (expand-file-name (file-name-directory keyword)))))
+    (let* ((candidates (list))
+          (parent-dir (ignore-errors (expand-file-name (file-name-directory (thing-at-point 'filename))))))
       (when (and parent-dir
                  (file-exists-p parent-dir))
         (let ((current-file (file-name-base keyword))
@@ -108,7 +108,6 @@
                                                :annotation (capitalize file-type)
                                                :backend "path")
                              t))))))
-
       (acm-candidate-sort-by-prefix keyword candidates))))
 
 (defun acm-backend-path-candidate-expand (candidate-info bound-start)

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -820,7 +820,10 @@ you can customize `lsp-bridge-get-project-path-by-filepath' to return project pa
         acm-backend-lsp-filepath
         (string-suffix-p ".vue" acm-backend-lsp-filepath))
    ;; Other language not allowed popup completion in string, it's annoy
-   (not (lsp-bridge-in-string-p))))
+   (not (lsp-bridge-in-string-p))
+   ;; Allow file path completion in string area
+   (and (thing-at-point 'filename)
+        (file-exists-p (file-name-directory (thing-at-point 'filename))))))
 
 (defun lsp-bridge-not-in-comment ()
   "Hide completion if cursor in comment area."


### PR DESCRIPTION
1. 原来的直接使用 keyword 来获取parent-dir 体验不好， 必须从头到尾开始输路径才能补全， 使用 (thing-at-point 'filename) 体验会更好
2. 增加了在字符串中补全目录路径， 一般来说， 路径都是在字符串里的， 没这个支持的话，只能先写好路径再加双引号
3. 这个补丁虽然能在字符串中补全，但是有一个小BUG，如下所示
`"~/emacs_notes/Android/"`  
尝试补全上述路径， 如果Android/ 都是手动输入的话，可以正常弹出补全窗口， 如果Android 是按回车补全的话，再输入 / 就不会弹出补全选项，删掉/再输入/又可以正常弹出，尝试了半天，没有找到合适的办法 