### PR TITLE
fix: Correct displaying of elisp documentation

### DIFF
--- a/acm/acm-backend-elisp.el
+++ b/acm/acm-backend-elisp.el
@@ -7,8 +7,8 @@
 ;; Copyright (C) 2022, Andy Stewart, all rights reserved.
 ;; Created: 2022-06-07 08:55:28
 ;; Version: 0.1
-;; Last-Updated: 2022-06-07 08:55:28
-;;           By: Andy Stewart
+;; Last-Updated: 2022-10-02 13:24:43 +0800
+;;           By: Gong Qijian
 ;; URL: https://www.github.org/manateelazycat/acm-backend-elisp
 ;; Keywords:
 ;; Compatibility: GNU Emacs 28.1
@@ -123,14 +123,15 @@
   (acm-doc-show))
 
 (defun acm-backend-elisp-candidate-doc (candidate)
-  (let* ((symbol (intern (plist-get candidate :label)))
-         (doc (ignore-errors (documentation symbol))))
-    (cond (doc
-           doc)
-          ((facep symbol)
-           (documentation-property symbol 'face-documentation))
-          (t
-           (documentation-property symbol 'variable-documentation)))))  
+  (let ((symbol (intern (plist-get candidate :label))))
+    (or (cond ((fboundp symbol)
+               (or (documentation symbol)
+                   (format "%s: %s" symbol (elisp-get-fnsym-args-string symbol))))
+              ((facep symbol)
+               (documentation-property symbol 'face-documentation))
+              (t
+               (documentation-property symbol 'variable-documentation)))
+        "Not documented")))
 
 (defun acm-backend-elisp-symbol-type (symbol)
   (cond ((featurep symbol)


### PR DESCRIPTION
In elisp mode, doc frame shows the previous documentation if current symbol is undocumented.

Steps to reproduce:

1. Launch `emacs -Q`.
1. Switch to `*scratch*`.
1. Load `lsp-bridge` and enable it.
1. Type `fill`.
1. Menu frame and doc frame showing:
![Screenshot_2022-10-02_at_2 19 50_PM](https://user-images.githubusercontent.com/2653486/193440901-4f5748a4-b182-43b7-a56d-a2f323081408.png)
1. Press `C-n` forward to next.
1. Doc frame still showing the previous documentation:
![Screenshot_2022-10-02_at_2 20 02_PM](https://user-images.githubusercontent.com/2653486/193440911-8db7e6c1-160f-4b35-8cf9-3d1a22d6e495.png)

