### PR TITLE
Fix issue that sometimes can't get documentation

### DIFF
--- a/acm/acm-backend-lsp.el
+++ b/acm/acm-backend-lsp.el
@@ -7,8 +7,8 @@
 ;; Copyright (C) 2022, Andy Stewart, all rights reserved.
 ;; Created: 2022-06-07 08:56:16
 ;; Version: 0.1
-;; Last-Updated: 2022-06-07 08:56:16
-;;           By: Andy Stewart
+;; Last-Updated: 2022-10-10 14:09:54 +0800
+;;           By: Gong Qijian
 ;; URL: https://www.github.org/manateelazycat/acm-backend-lsp
 ;; Keywords:
 ;; Compatibility: GNU Emacs 28.1
@@ -200,7 +200,8 @@
 (defun acm-backend-lsp-candidate-doc (candidate)
   (let* ((documentation (plist-get candidate :documentation)))
     ;; Call fetch documentation function.
-    (when acm-backend-lsp-fetch-completion-item-func
+    (when (and acm-backend-lsp-fetch-completion-item-func
+               (not (and documentation (not (string-empty-p documentation)))))
       (funcall acm-backend-lsp-fetch-completion-item-func candidate))
 
     documentation))

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -7,8 +7,8 @@
 ;; Copyright (C) 2018, Andy Stewart, all rights reserved.
 ;; Created: 2018-06-15 14:10:12
 ;; Version: 0.5
-;; Last-Updated: Wed May 11 02:44:16 2022 (-0400)
-;;           By: Mingde (Matthew) Zeng
+;; Last-Updated: 2022-10-10 15:23:53 +0800
+;;           By: Gong Qijian
 ;; URL: https://github.com/manateelazycat/lsp-bridge
 ;; Keywords:
 ;; Compatibility: emacs-version >= 28
@@ -98,14 +98,13 @@
 
 (defvar-local lsp-bridge-completion-item-fetch-tick nil)
 (defun lsp-bridge-fetch-completion-item-info (candidate)
-  (let* ((label (plist-get candidate :label))
-         (kind (plist-get candidate :icon))
-         (server-name (plist-get candidate :server))
-         (key (plist-get candidate :key)))
+  (let ((kind (plist-get candidate :icon))
+        (server-name (plist-get candidate :server))
+        (key (plist-get candidate :key)))
     ;; Try send `completionItem/resolve' request to fetch `documentation' and `additionalTextEdits' information.
-    (unless (equal lsp-bridge-completion-item-fetch-tick (list acm-backend-lsp-filepath label kind))
+    (unless (equal lsp-bridge-completion-item-fetch-tick (list acm-backend-lsp-filepath key kind))
       (lsp-bridge-call-async "fetch_completion_item_info" acm-backend-lsp-filepath key server-name)
-      (setq-local lsp-bridge-completion-item-fetch-tick (list acm-backend-lsp-filepath label kind)))))
+      (setq-local lsp-bridge-completion-item-fetch-tick (list acm-backend-lsp-filepath key kind)))))
 
 (defcustom lsp-bridge-completion-popup-predicates '(lsp-bridge-not-only-blank-before-cursor
                                                     lsp-bridge-not-match-hide-characters
@@ -812,6 +811,7 @@ So we build this macro to restore postion after code format."
     (setq-local acm-backend-lsp-completion-position position)
     (setq-local acm-backend-lsp-completion-trigger-characters completion-trigger-characters)
     (setq-local acm-backend-lsp-server-names server-names)
+    (setq-local lsp-bridge-completion-item-fetch-tick nil)
     (let* ((lsp-items acm-backend-lsp-items)
            (completion-table (make-hash-table :test 'equal)))
       (dolist (item candidates)


### PR DESCRIPTION
* acm/acm-backend-lsp.el (acm-backend-lsp-candidate-doc): Don't fetch the documentation if it is not empty.
* lsp-bridge.el (lsp-bridge-fetch-completion-item-info): Replace `label` with `key` in the judgment condition, make the logic consistent with `FileAction.completion_item_resolve`.
(lsp-bridge-completion--record-items): Reset fetch tick