### PR TITLE
Add Phpactor as PHP's Language Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ You need to install the LSP server corresponding to each programming language, t
 |    40 | [sourcekit-lsp](https://github.com/apple/sourcekit-lsp)                                            | swift                           | The SourceKit-LSP server is included with the Swift toolchain.                                                                                                          |
 |    41 | [omnisharp](https://github.com/OmniSharp/omnisharp-roslyn)                                         | c#                              | OmniSharp is a .NET development platform based on Roslyn workspaces. use `M-x lsp-bridge-install-omnisharp` to install it                                               |
 |    42 | [deno](https://deno.land)                                         | Deno                              | Deno runtime use TypeScript as source code, you need customize option `lsp-bridge-get-single-lang-server-by-project` that return result "deno" when `project-path` match Deno project.             |
+|    43 | [Phpactor](https://github.com/phpactor/phpactor)                                                   | php                             |                                                                                                                                                                         |
 
 
 ### Features that won't be supported

--- a/langserver/intelephense.json
+++ b/langserver/intelephense.json
@@ -1,5 +1,5 @@
 {
-  "name": "php",
+  "name": "intelephense",
   "languageId": "php",
   "command": [
     "intelephense",

--- a/langserver/phpactor.json
+++ b/langserver/phpactor.json
@@ -1,0 +1,9 @@
+{
+  "name": "phpactor",
+  "languageId": "php",
+  "command": [
+    "phpactor",
+    "--stdio"
+  ],
+  "settings": {}
+}

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -323,6 +323,11 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
   "Default LSP server for C language, you can choose `clangd' or `ccls'."
   :type 'string)
 
+(defcustom lsp-bridge-php-lsp-server "intelephense"
+  "Default LSP server for PHP language, you can choose `intelephense' or `phpactor'."
+  :type 'string
+  :safe #'stringp)
+
 (defcustom lsp-bridge-python-lsp-server "pyright"
   "Default LSP server for Python language, you can choose `pyright', `jedi', `python-ms'."
   :type 'string)
@@ -367,7 +372,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     ((sh-mode) . "bash-language-server")
     ((css-mode) . "vscode-css-language-server")
     (elm-mode . "elm-language-server")
-    (php-mode . "intelephense")
+    (php-mode . lsp-bridge-php-lsp-server)
     (yaml-mode . "yaml-language-server")
     (zig-mode . "zls")
     (dockerfile-mode . "docker-langserver")


### PR DESCRIPTION
[Phpactor](https://github.com/phpactor/phpactor) is an implementation of PHP's Language Server.