### PR TITLE
Add TAB key as acm-complete

### DIFF
--- a/acm/acm.el
+++ b/acm/acm.el
@@ -174,6 +174,7 @@
     (define-key map [remap previous-line] #'acm-select-prev)
     (define-key map [down] #'acm-select-next)
     (define-key map [up] #'acm-select-prev)
+    (define-key map [tab]  #'acm-complete)
     (define-key map "\M-n" #'acm-select-next)
     (define-key map "\M-p" #'acm-select-prev)
     (define-key map "\M-," #'acm-select-last)


### PR DESCRIPTION
`\t` (same as `(kbd "TAB")`) is already added, but it seems necessary to set `[tab]` to complete when Tab key is pressed in GUI Emacs.

Sorry if you didn't set it on purpose.