### PR TITLE
Proposal: Activate lsp-bridge-render-markdown-content on acm-doc

### DIFF
--- a/acm/acm.el
+++ b/acm/acm.el
@@ -867,6 +867,7 @@ The key of candidate will change between two LSP results."
             (with-current-buffer (get-buffer-create acm-doc-buffer)
               (erase-buffer)
               (insert candidate-doc)
+              (lsp-bridge-render-markdown-content)
               (visual-line-mode 1))
 
             ;; Adjust doc frame position and size.

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1836,6 +1836,15 @@ SymbolKind (defined in the LSP)."
 (defvar lsp-bridge-lookup-doc-tooltip-background nil)
 (defvar lsp-bridge-lookup-doc-tooltip-height nil)
 
+(defvar lsp-bridge-lookup-doc-tooltip-prettify-symbols-alist
+  (nconc
+   (cl-loop for i from 0 to 255
+            collect (cons (format "&#x%02X;" i) i))
+   '(("\\!" . ?!) ("\\#" . ?#) ("\\*" . ?*) ("\\+" . ?+) ("\\:" . ?:)
+     ("\\<" . ?<) ("\\>" . ?>) ("\\[" . ?\[) ("\\]" . ?\]) ("\\^" . ?^)
+     ("\\_" . ?_) ("\\`" . ?`) ("\\|" . ?|) ("\\~" . ?~) ("\\\\" . ?\\)
+     ("&lt;" . ?<) ("&gt;" . ?>) ("&amp;" . ?&))))
+
 (defun lsp-bridge-render-markdown-content ()
   (when (fboundp 'gfm-view-mode)
     (let ((inhibit-message t))
@@ -1846,6 +1855,9 @@ SymbolKind (defined in the LSP)."
       (set-face-attribute 'markdown-code-face nil :height lsp-bridge-lookup-doc-tooltip-font-height)
       (gfm-view-mode)))
   (read-only-mode 0)
+  (setq prettify-symbols-alist lsp-bridge-lookup-doc-tooltip-prettify-symbols-alist)
+  (setq prettify-symbols-compose-predicate (lambda (_start _end _match) t))
+  (prettify-symbols-mode 1)
   (font-lock-ensure))
 
 (defun lsp-bridge-toggle-sdcv-helper ()


### PR DESCRIPTION
Language servers return the doc as Markdown, so it's convenient to render it.

## Before

<img width="787" alt="スクリーンショット 2022-11-08 21 46 10" src="https://user-images.githubusercontent.com/822086/200568723-0f45b377-3b5f-4d01-b0f8-485b2c07d312.png">

## After

<img width="382" alt="スクリーンショット 2022-11-08 21 57 43" src="https://user-images.githubusercontent.com/822086/200571002-3e4ce3d3-f604-494f-bcda-165febf5e270.png">
