### PR TITLE
Fix markdown version

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -12,7 +12,7 @@
 ;; URL: https://github.com/manateelazycat/lsp-bridge
 ;; Keywords:
 ;; Compatibility: emacs-version >= 28
-;; Package-Requires: ((emacs "28") (posframe "1.1.7") (markdown-mode "2.6-dev"))
+;; Package-Requires: ((emacs "28") (posframe "1.1.7") (markdown-mode "2.6"))
 ;;
 ;; Features that might be required by this library:
 ;;


### PR DESCRIPTION
`2.6-dev` is an invalid version, make emacs can't install lsp-bridge with `package-vc-install`.