### PR TITLE
Add acm-enable-doc-markdown-render for apply rich style

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ It should be noted that there are three scan modes of lsp-bridge:
 * `lsp-bridge-completion-hide-characters`: completion menu will not popup when cursor after those characters
 * `acm-markdown-render-font-height`: The font height of function documentation, default is 130
 * `acm-enable-doc`: Whether the complete menu display the help document
+* `acm-enable-doc-markdown-render`: Richly render Markdown for completion popups, you can choose `'async`, `t` or `nil`. When set to `'async`, styles are applied asynchronously, enable by default.
 * `acm-enable-icon`: Whether the complete menu shows the icon, macOS users need to add option `--with-rsvg` to the brew command to install emacs to display SVG icon
 * `acm-enable-tabnine`: Enable tabnine support， enable by default，when enable need execute  `lsp-bridge-install-tabnine` command to install TabNine, and it can be used. TabNine will consume huge CPUs, causing your entire computer to be slow. If the computer performance is not good, it is not recommended to enable this option
 * `acm-enable-search-file-words`: Whether the complete menu display the word of the file, enable by default

--- a/acm/acm.el
+++ b/acm/acm.el
@@ -133,6 +133,13 @@
   :type 'boolean
   :group 'acm)
 
+(defcustom acm-enable-doc-markdown-render 'async
+  "Popup documentation automatically when this option is turn on."
+  :type '(choice (const :tag "Asynchronous" async)
+                 (const :tag "Enabled" t)
+                 (const :tag "Disabled" nil))
+  :group 'acm)
+
 (defcustom acm-enable-icon t
   "Show icon in completion menu."
   :type 'boolean
@@ -909,10 +916,12 @@ The key of candidate will change between two LSP results."
             ;; Only render markdown styling when idle 200ms, because markdown render is expensive.
             (when (string-equal backend "lsp")
               (acm-cancel-timer acm-markdown-render-timer)
-              (setq acm-markdown-render-timer
-                    (run-with-idle-timer 0.2 nil
-                                         (lambda ()
-                                           (acm-doc-markdown-render-content doc)))))
+              (cl-case acm-enable-doc-markdown-render
+                (async (setq acm-markdown-render-timer
+                             (run-with-idle-timer 0.2 nil
+                                                  (lambda ()
+                                                    (acm-doc-markdown-render-content doc)))))
+                ((t) (acm-doc-markdown-render-content doc))))
 
             ;; Adjust doc frame position and size.
             (acm-doc-frame-adjust))


### PR DESCRIPTION
refs https://github.com/manateelazycat/lsp-bridge/pull/406#issuecomment-1334633908

Rendering immediately doesn't stress me out in my environment, so I'd like to be able to customize sync/async and invalidation.