### PR TITLE
Use bound-and-true-p instead of symbol-value

### DIFF
--- a/acm/acm-backend-lsp.el
+++ b/acm/acm-backend-lsp.el
@@ -230,8 +230,7 @@ If optional MARKER, return a marker instead"
 (defun acm-backend-lsp-snippet-expansion-fn ()
   "Compute a function to expand snippets.
 Doubles as an indicator of snippet support."
-  (and (boundp 'yas-minor-mode)
-       (symbol-value 'yas-minor-mode)
+  (and (bound-and-true-p 'yas-minor-mode)
        'yas-expand-snippet))
 
 (defun acm-backend-lsp-insert-new-text (start-pos end-pos new-text)


### PR DESCRIPTION
This is a minor fix: `bound-and-true-p` simplifies the code slightly.

There is no change in behavior in this case, but `bound-and-true-p` behaves more intuitively in most cases. This is because `symbol-value` does not work as expected for lexically bound variables.