### PR TITLE
Fix acm-backend-citre-candidates

### DIFF
--- a/acm/acm-backend-citre.el
+++ b/acm/acm-backend-citre.el
@@ -185,7 +185,12 @@
             (setq-local acm-backend-citre-search-keyword (concat acm-backend-citre-search-keyword (substring (string-reverse keyword) 0 1)))
           (setq-local acm-backend-citre-search-keyword keyword)))
       (let* ((collection (unless (string-empty-p acm-backend-citre-search-keyword)
-                           (delete-dups (citre-capf--get-collection acm-backend-citre-search-keyword)))))
+                           (pcase-let
+                               ((`(closure ((cands . ,cands) . ,_) . ,_)
+                                 (let ((cands (citre-get-completions)))
+                                   (nth 2 (citre-capf--make-collection
+                                           (nth 2 cands) (nth 0 cands) (nth 1 cands))))))
+                             (delete-dups cands)))))
         (when acm-backend-citre-keyword-complete
           (setq collection (append (acm-backend-citre-get-mode-keyword) collection)))
         (when collection


### PR DESCRIPTION
The function `citre-capf--get-collection` was removed in https://github.com/universal-ctags/citre/commit/00d915a