### PR TITLE
Don't hide completion if the char before cursor match acm-backend-lsp-completion-trigger-characters

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -922,7 +922,9 @@ So we build this macro to restore postion after code format."
 
 (defun lsp-bridge-not-match-hide-characters ()
   "Hide completion if char before cursor match `lsp-bridge-completion-hide-characters'."
-  (not (member (ignore-errors (char-to-string (char-before))) lsp-bridge-completion-hide-characters)))
+  (let ((char (ignore-errors (char-to-string (char-before)))))
+    (or (member char (bound-and-true-p acm-backend-lsp-completion-trigger-characters))
+        (not (member char lsp-bridge-completion-hide-characters)))))
 
 (defun lsp-bridge-is-evil-state ()
   "If `evil' mode is enable, only show completion when evil is in insert mode."

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -977,6 +977,28 @@ So we build this macro to restore postion after code format."
     (setq-local lsp-bridge--before-change-begin-pos (lsp-bridge--point-position begin))
     (setq-local lsp-bridge--before-change-end-pos (lsp-bridge--point-position end))))
 
+(defun lsp-bridge-monitor-post-self-insert ()
+  ;; Make sure this function be called after `electric-pair-mode'
+  ;; `smartparens-mode' or something similar if they are enabled.
+  ;;
+  ;; Because pairing parethness or quotes will call `after-change-functions'
+  ;; multiple times. For example: (| represents the cursor)
+  ;;
+  ;;         dic|
+  ;;
+  ;; Press `[', then the following situation will be observed in
+  ;; `lsp-bridge-monitor-after-change':
+  ;;
+  ;;         dic[|
+  ;;         dic|
+  ;;         dic[|
+  ;;         dic[]|
+  ;;
+  ;; The last position of cursor is wrong, that makes a misjudgment in
+  ;; `lsp-bridge-try-completion'.
+  (setq lsp-bridge-last-change-position
+        (list (current-buffer) (buffer-chars-modified-tick) (point))))
+
 (defun lsp-bridge-monitor-after-change (begin end length)
   (unless lsp-bridge-revert-buffer-flag
     ;; Record last command to `lsp-bridge-last-change-command'.
@@ -1297,13 +1319,14 @@ So we build this macro to restore postion after code format."
 (add-hook 'post-command-hook 'lsp-bridge-monitor-window-buffer-change)
 
 (defconst lsp-bridge--internal-hooks
-  '((before-change-functions . lsp-bridge-monitor-before-change)
-    (after-change-functions . lsp-bridge-monitor-after-change)
-    (post-command-hook . lsp-bridge-monitor-post-command)
-    (after-save-hook . lsp-bridge-monitor-after-save)
-    (kill-buffer-hook . lsp-bridge-close-buffer-file)
-    (find-file-hook . lsp-bridge-search-words-open-file)
-    (before-revert-hook . lsp-bridge-close-buffer-file)
+  '((before-change-functions lsp-bridge-monitor-before-change nil t)
+    (after-change-functions lsp-bridge-monitor-after-change nil t)
+    (post-command-hook lsp-bridge-monitor-post-command nil t)
+    (after-save-hook lsp-bridge-monitor-after-save nil t)
+    (kill-buffer-hook lsp-bridge-close-buffer-file nil t)
+    (find-file-hook lsp-bridge-search-words-open-file nil t)
+    (before-revert-hook lsp-bridge-close-buffer-file nil t)
+    (post-self-insert-hook lsp-bridge-monitor-post-self-insert 90 t)
     ))
 
 (defvar lsp-bridge-mode-map (make-sparse-keymap))
@@ -1409,7 +1432,7 @@ Default is 0.5 second, preview window will stick if this value too small."
       (acm-run-idle-func lsp-bridge-auto-format-code-timer lsp-bridge-auto-format-code-idle 'lsp-bridge-auto-format-code)))
 
   (dolist (hook lsp-bridge--internal-hooks)
-    (add-hook (car hook) (cdr hook) nil t))
+    (apply #'add-hook hook))
 
   (advice-add #'acm-hide :after #'lsp-bridge--completion-hide-advisor)
 
@@ -1421,7 +1444,7 @@ Default is 0.5 second, preview window will stick if this value too small."
   "Disable LSP Bridge mode."
   ;; Remove hooks.
   (dolist (hook lsp-bridge--internal-hooks)
-    (remove-hook (car hook) (cdr hook) t))
+    (remove-hook (nth 0 hook) (nth 1 hook) (nth 3 hook)))
 
   ;; Cancel idle timer.
   (acm-cancel-timer lsp-bridge-signature-help-timer)


### PR DESCRIPTION
For example in python we need keyword completion for dictionary:

    dic|                            # Type [ to trigger the keyword completion

![Screenshot_2022-12-08_at_1 45 47_PM](https://user-images.githubusercontent.com/2653486/206369297-aa1b4155-f12b-449c-8f5f-9606c45d77ce.png)

But there are two issues that stopped the completion before that:

1. The `lsp-bridge-last-change-position` records wrong position if electric-pair-mode or smartparens-mode enabled.
2. The `lsp-bridge-not-match-hide-characters` returns nil even if the char is a **triggerCharacter**.

### Steps to reproduce:

1. Prepare test file:

```sh
$ cat test.py
movie = {
    'title': 'Avator',
    'year': '2006',
    'director': 'Martin Scorsese'
}

movie
```

2. Start emacs:

```sh
$ emacs -Q --eval "\
  (progn
    (toggle-debug-on-error)

    (require 'seq)
    (setq user-emacs-directory
          (car (seq-filter
                #'file-exists-p
                (list (format \"~/.emacs.d/%s/\" emacs-version)
                      (format \"~/.emacs.d/%s.%s/\"
                              emacs-major-version emacs-minor-version)
                      \"~/.emacs.d/\"))))
    (setq package-user-dir (concat user-emacs-directory \"elpa/\"))
    (package-initialize)

    (add-to-list 'load-path \"~/repos/emacs-lsp-bridge\")

    (require 'yasnippet)
    (yas-global-mode 1)

    (require 'lsp-bridge)
    (global-lsp-bridge-mode)

    (electric-pair-mode 1)

    (unless (display-graphic-p)
      (add-to-list 'load-path \"~/repos/emacs-popon\")
      (add-to-list 'load-path \"~/repos/emacs-acm-terminal\")
      (require 'acm-terminal)))" test.py 
```

3. Type `[`

### Behaviour before fix

![Screenshot_2022-12-08_at_1 54 46_PM](https://user-images.githubusercontent.com/2653486/206368950-683338d0-63e9-4739-947f-753b3000da14.png)

`*lsp-bridge*` shows that there are 3 candidates but the completion is not triggered.

### Behaviour after fix

![Screenshot_2022-12-08_at_1 48 14_PM](https://user-images.githubusercontent.com/2653486/206369143-87254647-8a73-4265-9a66-b793305fad3b.png)

