### PR TITLE
feat: Allow popup completion menu for string interpolation

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -520,9 +520,18 @@ you can customize `lsp-bridge-get-workspace-folder' to return workspace folder p
   "A mapping from `major-mode' to its indent variable.")
 
 (defcustom lsp-bridge-string-interpolation-open-chars-alist
-  '((python-mode . "[^\$]\{")
-    (yaml-mode . "\{\{")
-    (t . "\$\{"))
+  '(;;; for {}
+    (python-mode . "[^\$]\{")
+    ;;; for ${}
+    (js-mode . "\$\{")
+    (js2-mode . "\$\{")
+    (js3-mode . "\$\{")
+    (typescript-mode . "\$\{")
+    (sh-mode . "\$\{")
+    ;;; for #{}
+    (ruby-mode . "\#\{")
+    ;;; for {{}}
+    (yaml-mode . "\{\{"))
   "Open characters for string interpolation. The elements are cons cell (major-mode . open-char-regexp)"
   :type 'cons)
 

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -951,14 +951,12 @@ So we build this macro to restore postion after code format."
 
 (defun lsp-bridge-string-interpolation-p (string-interpolation-open-chars-alist)
   "Check if the cursor position is subject to string interpolation"
-  (save-excursion
-    (let* ((initial-pos (point))
-           (search-char (cdr (or (assoc (buffer-local-value 'major-mode (current-buffer))
-                                        string-interpolation-open-chars-alist)
-                                 (assoc t string-interpolation-open-chars-alist))))
-           (open-pos (search-backward-regexp search-char nil t)))
-      (if open-pos
-          (not (search-forward-regexp "\}" initial-pos t))))))
+  (let ((search-char (cdr (assoc (buffer-local-value 'major-mode (current-buffer))
+                                 string-interpolation-open-chars-alist))))
+    (when search-char
+      (let ((open-pos (save-excursion (search-backward-regexp search-char nil t))))
+        (when open-pos
+          (not (save-excursion (search-backward-regexp "\}" open-pos t))))))))
 
 (defun lsp-bridge-not-in-string ()
   "Hide completion if cursor in string area."


### PR DESCRIPTION
Thank you for developing this wonderful package.

I propose new feature to allow popup completion menu for string interpolation.
This only works with string interpolation.

For example in python-mode,

no popup menu in string,
![image](https://user-images.githubusercontent.com/29372455/210169956-c99998c1-34bd-4a88-8f27-b640bea7a0dc.png)

popup menu in string interpolation,
![image](https://user-images.githubusercontent.com/29372455/210169981-e3a762b4-24da-4726-9476-3a63fed20023.png)
