### PR TITLE
add lsp-bridge-user-langserver-dir/lsp-bridge-user-multiserver-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ It should be noted that there are three scan modes of lsp-bridge:
 * `lsp-bridge-completion-popup-predicates`: the predicate function for completion menu, completion menu popup after all the functions pass
 * `lsp-bridge-completion-stop-commands`: completion menu will not popup if these commands are executed
 * `lsp-bridge-completion-hide-characters`: completion menu will not popup when cursor after those characters
+* `lsp-bridge-user-langserver-dir`: the dir where user place langserver configuration file, if the configuration file name in the dir is the same as that in [lsp-bridge/langserver](https://github.com/manateelazycat/lsp-bridge/tree/master/langserver) , lsp-bridge will use the configuration file in this dir
+* `lsp-bridge-user-multiserver-dir`: the dir where user place multiserver configuration file, if the configuration file name in the dir is the same as that in [lsp-bridge/multiserver](https://github.com/manateelazycat/lsp-bridge/tree/master/multiserver) , lsp-bridge will use the configuration file in this dir
 * `acm-frame-background-dark-color`: Menu background color in dark theme
 * `acm-frame-background-light-color`: Menu background color in light theme
 * `acm-markdown-render-font-height`: The font height of function documentation, default is 130
@@ -176,6 +178,21 @@ For example, we can enable the Deno LSP server for the Deno script with the foll
                   (when (search-forward-regexp (regexp-quote "from \"https://deno.land") nil t)
                     (return "deno")))))))))
 ```
+
+## Customize language server configuration file
+Copy the configuration file in  [lsp-bridge/langserver](https://github.com/manateelazycat/lsp-bridge/tree/master/langserver) or [lsp-bridge/multiserver](https://github.com/manateelazycat/lsp-bridge/tree/master/multiserver) to `lsp-bridge-user-langserver-dir` or `lsp-bridge-user-multiserver-dir` for customization, lsp-bridge will read the configuration file in `lsp-bridge-user-langserver-dir` or `lsp-bridge-user-multiserver-dir` first.
+
+We can set the value of `lsp-bridge-user-langserver-dir` or `lsp-bridge-user-multiserver-dir` before starting `lsp-bridge-mode` to realize different configuration files for different projects.
+
+```elisp
+(defun enable-lsp-bridge()
+  (when-let* ((project (project-current))
+              (project-root (nth 2 project)))
+    (setq-local lsp-bridge-user-langserver-dir project-root
+                lsp-bridge-user-multiserver-dir project-root))
+  (lsp-bridge-mode))
+```
+
 
 ## Add support for new language?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -123,6 +123,8 @@ lsp-bridge 开箱即用， 安装好语言对应的[LSP 服务器](https://githu
 * `lsp-bridge-completion-popup-predicates`: 补全菜单显示的检查函数， 这个选项包括的所有函数都检查过以后， 补全菜单才能显示
 * `lsp-bridge-completion-stop-commands`: 这些命令执行以后，不再弹出补全菜单
 * `lsp-bridge-completion-hide-characters`: 这些字符的后面不再弹出补全菜单
+* `lsp-bridge-user-langserver-dir`: 用户 langserver 配置文件目录，如果目录下的配置文件和 [lsp-bridge/langserver](https://github.com/manateelazycat/lsp-bridge/tree/master/langserver) 里的配置文件同名，lsp-bridge 会使用这个目录下的配置文件
+* `lsp-bridge-user-multiserver-dir`: 用户 multiserver 配置文件目录，如果目录下的配置文件和 [lsp-bridge/multiserver](https://github.com/manateelazycat/lsp-bridge/tree/master/multiserver) 里的配置文件同名，lsp-bridge 会使用这个目录下的配置文件
 * `acm-frame-background-dark-color`: 暗色主题下的菜单背景颜色
 * `acm-frame-background-light-color`: 亮色主题下的菜单背景颜色
 * `acm-markdown-render-font-height`: 弹出文档的字体高度， 默认是 130
@@ -173,6 +175,20 @@ lsp-bridge 每种语言的服务器配置存储在[lsp-bridge/langserver](https:
                   (goto-char (point-min))
                   (when (search-forward-regexp (regexp-quote "from \"https://deno.land") nil t)
                     (return "deno")))))))))
+```
+
+## 自定义语言服务器配置文件
+拷贝 [lsp-bridge/langserver](https://github.com/manateelazycat/lsp-bridge/tree/master/langserver) 或 [lsp-bridge/multiserver](https://github.com/manateelazycat/lsp-bridge/tree/master/multiserver) 中的配置文件到 `lsp-bridge-user-langserver-dir` 或 `lsp-bridge-user-multiserver-dir` 中进行自定义，lsp-bridge 会优先读取 `lsp-bridge-user-langserver-dir` 或 `lsp-bridge-user-multiserver-dir` 里的配置文件。
+
+我们可以在启动 `lsp-bridge-mode` 之前设置 `lsp-bridge-user-langserver-dir` 或 `lsp-bridge-user-multiserver-dir` 的值，实现不同的工程用不同的配置文件
+
+```elisp
+(defun enable-lsp-bridge()
+  (when-let* ((project (project-current))
+              (project-root (nth 2 project)))
+    (setq-local lsp-bridge-user-langserver-dir project-root
+                lsp-bridge-user-multiserver-dir project-root))
+  (lsp-bridge-mode))
 ```
 
 

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -235,6 +235,16 @@ Setting this to nil or 0 will turn off the indicator."
   :type 'float
   :group 'lsp-bridge)
 
+(defcustom lsp-bridge-user-langserver-dir nil
+  "The directory where the user place langserver configuration."
+  :type 'string
+  :group 'lsp-bridge)
+
+(defcustom lsp-bridge-user-multiserver-dir nil
+  "The directory where the user place multiserver configuration."
+  :type 'string
+  :group 'lsp-bridge)
+
 (defface lsp-bridge-font-lock-flash
   '((t (:inherit highlight)))
   "Face to flash the current line."

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -170,6 +170,11 @@ class LspBridge:
             multi_lang_server_dir = Path(__file__).resolve().parent / "multiserver"
             multi_lang_server_path = multi_lang_server_dir / "{}.json".format(multi_lang_server)
             
+            user_multi_lang_server_dir = Path(str(get_emacs_var("lsp-bridge-user-multiserver-dir")))
+            user_multi_lang_server_path = user_multi_lang_server_dir / "{}.json".format(multi_lang_server)
+            if user_multi_lang_server_path.exists():
+                multi_lang_server_path = user_multi_lang_server_path
+
             with open(multi_lang_server_path, encoding="utf-8", errors="ignore") as f:
                 multi_lang_server_info = json.load(f)
                 servers = self.pick_multi_server_names(multi_lang_server_info)
@@ -374,6 +379,15 @@ def get_lang_server_path(server_name):
     server_dir = Path(__file__).resolve().parent / "langserver"
     server_path_current = server_dir / "{}_{}.json".format(server_name, get_os_name())
     server_path_default = server_dir / "{}.json".format(server_name)
+
+    user_server_dir = Path(str(get_emacs_var("lsp-bridge-user-langserver-dir")))
+    user_server_path_current = user_server_dir / "{}_{}.json".format(server_name, get_os_name())
+    user_server_path_default = user_server_dir / "{}.json".format(server_name)
+
+    if user_server_path_current.exists():
+        server_path_current = user_server_path_current
+    elif user_server_path_default.exists():
+        server_path_current = user_server_path_default
 
     return server_path_current if server_path_current.exists() else server_path_default
     


### PR DESCRIPTION
添加了两个选项，能够让用户定义 langserver 和 multiserver 目录放自己的语言服务配置文件，如果用户定义了同名的配置文件，用户目录的优先级更高


像 volar 里面 tsdk 路径是写死的，之前想改比较麻烦，加了这两个选项后就比较灵活了，可以每个工程目录下放一个 volar.json ，实现不同的工程读不同的配置文件


配置例子：
``` elisp
  (defun my-enable-lsp-bridge()
    "Enable lsp bridge mode."
    (require 'yasnippet)
    (yas-minor-mode)
    (require 'lsp-bridge)
    (when-let* ((project (project-current))
               (project-root (nth 2 project)))
      (setq-local lsp-bridge-user-langserver-dir project-root
                  lsp-bridge-user-multiserver-dir project-root))
    (lsp-bridge-mode))


```