### PR TITLE
Use `_` (wildcard) instead of `t` for pcase

### DIFF
--- a/acm/acm.el
+++ b/acm/acm.el
@@ -760,7 +760,7 @@ The key of candidate will change between two LSP results."
           ("lsp" (when update-completion-item
                    (acm-doc-hide)))
           ;; Hide doc frame immediately if backend is not LSP.
-          (t (acm-doc-hide)))))))
+          (_ (acm-doc-hide)))))))
 
 (defun acm-doc-frame-adjust ()
   (let* ((emacs-width (frame-pixel-width))


### PR DESCRIPTION
```
lsp-bridge/acm/acm.el: Warning: Pattern t is deprecated.  Use `_' instead
```

See https://www.gnu.org/software/emacs/manual/html_node/elisp/pcase-Macro.html

https://github.com/emacsmirror/emacs/blob/013655811aa1c89754372610c8c6ccccec166035/lisp/emacs-lisp/pcase.el#L948-L951