### PR TITLE
fix(docs): sexpdata version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Lsp-bridge uses python's threading technology to build caches that bridge Emacs 
 ## Installation
 
 1. Install Emacs 28 and above versions
-2. Install Python dependencies: `pip3 install epc orjson sexpdata six` (orjson is optional, orjson is based on Rust, providing faster JSON parsing performance)
+2. Install Python dependencies: `pip3 install epc orjson sexpdata==0.0.3 six` (orjson is optional, orjson is based on Rust, providing faster JSON parsing performance)
 3. Install Elisp dependencies:
 + [posframe](https://github.com/tumashu/posframe)
 + [markdown-mode](https://github.com/jrblevin/markdown-mode)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,7 @@ lsp-bridge 使用 Python 多线程技术在 Emacs 和 LSP 服务器之间构建�
 ## 安装
 
 1. 安装 Emacs 28 及以上版本
-2. 安装 Python 依赖: `pip3 install epc orjson sexpdata six` (orjson 是可选的， orjson 基于 Rust， 提供更快的 JSON 解析性能)
+2. 安装 Python 依赖: `pip3 install epc orjson sexpdata==0.0.3 six` (orjson 是可选的， orjson 基于 Rust， 提供更快的 JSON 解析性能)
 3. 安装 Elisp 依赖:
 + [posframe](https://github.com/tumashu/posframe)
 + [markdown-mode](https://github.com/jrblevin/markdown-mode)


### PR DESCRIPTION
Feb 10, 2023，[sexpdata](https://pypi.org/project/sexpdata/#history) 发布了 0.0.4 版本，此版本会导致 epc 出现问题。故需指定版本为 0.0.3。