### PR TITLE
fix workspace/configuration handler when initial settings is empty

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -489,7 +489,7 @@ class LspServer:
         settings = self.server_info.get("settings", {})
 
         # We send empty message back to server if nothing in 'settings' of server.json file.
-        if len(settings) == 0:
+        if settings is None or len(settings) == 0:
             self.sender.send_response(request_id, [])
             return
 


### PR DESCRIPTION
* core/lspserver.py: check settings if is None before calling len()

```python
>>> dict = {'settings': None}
>>> settings = dict.get('settings', {})
>>> type(settings)
<class 'NoneType'>
```

```python
 settings = self.server_info.get("settings", {})
```
json配置里的settings为{}会被json解析为None，对于在字典中已经存在的关键字，值即使为None，get()也不会去取默认值，调用len()前需要再校验下settings的值