### PR TITLE
fix lsp-bridge-ref-open-file-and-stay

### DIFF
--- a/lsp-bridge-ref.el
+++ b/lsp-bridge-ref.el
@@ -839,7 +839,7 @@ user more freedom to use rg with special arguments."
             )))
       ;; Flash match line.
       (lsp-bridge-ref-flash-line))
-    (unless stay
+    (when stay
       ;; Keep cursor in search buffer's window.
       (setq ref-buffer-window (get-buffer-window lsp-bridge-ref-buffer))
       (if ref-buffer-window
@@ -858,19 +858,22 @@ user more freedom to use rg with special arguments."
   (lsp-bridge-ref-open-file t))
 
 (defun lsp-bridge-ref-flash-line ()
-  (let ((pulse-iterations 1)
-        (pulse-delay lsp-bridge-ref-flash-line-delay))
-    ;; Flash match line.
-    (pulse-momentary-highlight-one-line (point) 'lsp-bridge-ref-font-lock-flash)
-    ;; View the function name when navigate in match line.
-    (when lsp-bridge-ref-show-function-name-p
-      (require 'which-func)
-      (when-let ((function-name (which-function)))
-        (message "[LSP-Bridge] Located in function: %s"
-                 (propertize
-                  function-name
-                  'face 'lsp-bridge-ref-font-lock-function-location
-                  ))))))
+  (put 'pulse-iterations 'initial-value pulse-iterations)
+  (put 'pulse-delay 'initial-value pulse-delay)
+  (setq pulse-iterations 1
+        pulse-delay lsp-bridge-ref-flash-line-delay)
+  ;; Flash match line.
+  (pulse-momentary-highlight-one-line (point) 'lsp-bridge-ref-font-lock-flash)
+  ;; View the function name when navigate in match line.
+  (when lsp-bridge-ref-show-function-name-p
+    (require 'which-func)
+    (when-let ((function-name (which-function)))
+      (message "[LSP-Bridge] Located in function: %s"
+               (propertize
+                function-name
+                'face 'lsp-bridge-ref-font-lock-function-location))))
+  (setq pulse-iterations (get 'pulse-iterations 'initial-value)
+        pulse-delay (get 'pulse-delay 'initial-value)))
 
 (defun lsp-bridge-ref-in-org-link-content-p ()
   (and (looking-back "\\[\\[.*" (line-beginning-position))

--- a/lsp-bridge-ref.el
+++ b/lsp-bridge-ref.el
@@ -752,17 +752,21 @@ user more freedom to use rg with special arguments."
           (lsp-bridge-ref-open-file))
       (message "[LSP-Bridge] Reach to first line."))))
 
-(defun lsp-bridge-ref-jump-next-file ()
+(defun lsp-bridge-ref-jump-next-file (&optional stay)
   (interactive)
   (let*  ((next-position (lsp-bridge-ref-find-next-position lsp-bridge-ref-regexp-file)))
     (if next-position
         (progn
           (goto-char next-position)
           (forward-line)
-          (lsp-bridge-ref-open-file))
+          (lsp-bridge-ref-open-file stay))
       (message "[LSP-Bridge] Reach to last file."))))
 
-(defun lsp-bridge-ref-jump-prev-file ()
+(defun lsp-bridge-ref-jump-next-file-and-stay ()
+  (interactive)
+  (lsp-bridge-ref-jump-next-file t))
+
+(defun lsp-bridge-ref-jump-prev-file (&optional stay)
   (interactive)
   (let ((prev-match-pos
          (if (save-excursion (search-backward-regexp lsp-bridge-ref-regexp-file nil t))
@@ -787,8 +791,12 @@ user more freedom to use rg with special arguments."
         (progn
           (goto-char prev-match-pos)
           (forward-line)
-          (lsp-bridge-ref-open-file))
+          (lsp-bridge-ref-open-file stay))
       (message "[LSP-Bridge] Reach to first file."))))
+
+(defun lsp-bridge-ref-jump-prev-file-and-stay ()
+  (interactive)
+  (lsp-bridge-ref-jump-prev-file t))
 
 (defun lsp-bridge-ref-insert-current-line ()
   (interactive)

--- a/lsp-bridge-ref.el
+++ b/lsp-bridge-ref.el
@@ -858,6 +858,7 @@ user more freedom to use rg with special arguments."
   (lsp-bridge-ref-open-file t))
 
 (defun lsp-bridge-ref-flash-line ()
+  (require 'pulse)
   (put 'pulse-iterations 'initial-value pulse-iterations)
   (put 'pulse-delay 'initial-value pulse-delay)
   (setq pulse-iterations 1


### PR DESCRIPTION
1. There is an error `Defining as dynamic an already lexical var: pulse-iterations` if pulse.el is loaded
2. stay doesn't work as expected
3. Add lsp-bridge-ref-jump-next-file-and-stay & lsp-bridge-ref-jump-prev-file-and-stay, thus we can preview file content while navigating