### PR TITLE
fix ruff args

### DIFF
--- a/langserver/ruff.json
+++ b/langserver/ruff.json
@@ -5,7 +5,7 @@
   "initializationOptions": {
     "settings": {
       "args": ["--line-length=500",
-        "--ignore=F403,F405,E722, E402"]
+        "--ignore=F403,F405,E722,E402"]
     }
   },
   "settings": {}


### PR DESCRIPTION
```
--- [13:24:32.587127] Recv window/logMessage notification from 'ruff' for project t.py
{
   "params": {
      "type": 4,
      "message": "Running Ruff with: ['/sbin/ruff', '--no-cache', '--no-fix', '--quiet', '--format', 'json', '-', '--line-length=500', '--ignore=F403,F405,E722, E402', '--stdin-filename', '/home/harumi/t.py']"
   },
   "method": "window/logMessage",
   "jsonrpc": "2.0"
}

--- [13:24:32.592455] Recv window/logMessage notification from 'ruff' for project t.py
{
   "params": {
      "type": 4,
      "message": "error: Unknown rule selector ` E402`"
   },
   "method": "window/logMessage",
   "jsonrpc": "2.0"
}
```

should remove  whitespace before `E402`
