### PR TITLE
Support jdtls overrideMethodsPromptSupport

### DIFF
--- a/core/handler/__init__.py
+++ b/core/handler/__init__.py
@@ -60,3 +60,5 @@ from core.handler.execute_command import ExecuteCommand
 from core.handler.workspace_symbol import WorkspaceSymbol
 from core.handler.call_hierarchy import PrepareCallHierarchyIncomingCalls, PrepareCallHierarchyOutgoingCalls, CallHierarchyIncomingCalls, CallHierarchyOutgoingCalls
 from core.handler.document_symbol import DocumentSymbol
+from core.handler.jdtls.jdtls_list_overridable_methods import JdtlsListOverridableMethods
+from core.handler.jdtls.jdtls_add_overridable_methods import JdtlsAddOverridableMethods

--- a/core/handler/jdtls/jdtls_add_overridable_methods.py
+++ b/core/handler/jdtls/jdtls_add_overridable_methods.py
@@ -1,0 +1,17 @@
+from core.handler import Handler
+from core.utils import *
+import json
+
+
+class JdtlsAddOverridableMethods(Handler):
+    name = "jdtls_add_overridable_methods"
+    method = "java/addOverridableMethods"
+    cancel_on_change = True
+    send_document_uri = False
+
+    def process_request(self, paramsStr) -> dict:
+        return json.loads(paramsStr)
+
+    def process_response(self, response) -> None:
+        if response is not None and len(response) > 0:
+            eval_in_emacs("lsp-bridge-workspace-apply-edit", response)

--- a/core/handler/jdtls/jdtls_list_overridable_methods.py
+++ b/core/handler/jdtls/jdtls_list_overridable_methods.py
@@ -1,0 +1,25 @@
+from core.handler import Handler
+from core.utils import *
+import json
+
+class JdtlsListOverridableMethods(Handler):
+    name = "jdtls_list_overridable_methods"
+    method = "java/listOverridableMethods"
+    cancel_on_change = True
+    send_document_uri = False
+    context = None
+
+    def process_request(self, arguments) -> dict:
+        self.context = arguments
+        return arguments
+
+    def process_response(self, response) -> None:
+        if response is not None and len(response) > 0:
+            resp = {
+                "response": response,
+                "context": self.context
+            }
+            eval_in_emacs("lsp-bridge-jdtls-add-overridable-methods", json.dumps(resp))
+            self.context = None
+        else:
+            message_emacs("No Overridable methods found.")

--- a/core/utils.py
+++ b/core/utils.py
@@ -116,6 +116,9 @@ def epc_arg_transformer(arg):
     if type(arg) != list:
         return arg
 
+    # NOTE: Empty list elisp can be treated as both empty python dict/list
+    # Convert empty elisp list to empty python dict due to compatibility.
+
     # check if we can tranform arg to python dict instance
     type_dict_p = len(arg) % 2 == 0
     if type_dict_p:

--- a/langserver/jdtls.json
+++ b/langserver/jdtls.json
@@ -50,7 +50,8 @@
       }
     },
     "extendedClientCapabilities": {
-      "classFileContentsSupport": true
+      "classFileContentsSupport": true,
+      "overrideMethodsPromptSupport": true
     }
   }
 }

--- a/lsp-bridge-code-action.el
+++ b/lsp-bridge-code-action.el
@@ -328,7 +328,7 @@ Please read https://microsoft.github.io/language-server-protocol/specifications/
           ((plistp command)
            (lsp-bridge-code-action--fix-do command temp-buffer)))
     (unless temp-buffer
-      (message "[lsp-bridge] execute code action '%s'" (plist-get action :title)))))
+      (message "[LSP-BRIDGE] Execute code action '%s'" (plist-get action :title)))))
 
 (defun lsp-bridge-code-action--fix (actions action-kind)
   (let* ((menu-items

--- a/lsp-bridge-jdtls.el
+++ b/lsp-bridge-jdtls.el
@@ -109,7 +109,7 @@ E.g. Use `-javaagent:/home/user/.emacs.d/plugin/lombok.jar` to add lombok suppor
                                     (let* ((name (plist-get method :name))
                                            (parameters (plist-get method :parameters))
                                            (class (plist-get method :declaringClass)))
-                                      (cons (format "%s(%s) class: %s" name (s-join ", " parameters) class) method)))
+                                      (cons (format "%s(%s) class: %s" name (string-join parameters ", ") class) method)))
                                   methods))
               (selected-methods (cl-map 'vector
                                         (lambda (choice) (alist-get choice menu-items nil nil 'equal))

--- a/lsp-bridge-jdtls.el
+++ b/lsp-bridge-jdtls.el
@@ -87,5 +87,37 @@ E.g. Use `-javaagent:/home/user/.emacs.d/plugin/lombok.jar` to add lombok suppor
 (add-hook 'java-mode-hook (lambda ()
                             (setq-local lsp-bridge-get-single-lang-server-by-project 'lsp-bridge-get-jdtls-server-by-project)))
 
+(defun lsp-bridge-jdtls-apply-workspace-edit (action &optional temp-buffer)
+  "Command java.apply.workspaceEdit handler."
+  (let ((arguments (plist-get action :arguments)))
+    (dolist (argument arguments)
+      (lsp-bridge-workspace-apply-edit argument temp-buffer))))
+
+(defun lsp-bridge-jdtls-override-methods-prompt (action &optional temp-buffer)
+  "Command java.action.overrideMethodsPrompt handler."
+  (let ((argument (car (plist-get action :arguments))))
+    (lsp-bridge-call-file-api "jdtls_list_overridable_methods" argument)))
+
+(defun lsp-bridge-jdtls-add-overridable-methods (resp-json)
+  "Recv java/listOverridableMethods response and process java/addoverridablemethods command"
+  ;; NOTE: The reason using json-string directly is that lsp-bridge elisp object <-> python object is still unreliable
+  (when-let* ((resp (json-parse-string resp-json :object-type 'plist))
+              (response (plist-get resp :response))
+              (context (plist-get resp :context))
+              (methods (plist-get response :methods))
+              (menu-items (mapcar (lambda (method)
+                                    (let* ((name (plist-get method :name))
+                                           (parameters (plist-get method :parameters))
+                                           (class (plist-get method :declaringClass)))
+                                      (cons (format "%s(%s) class: %s" name (s-join ", " parameters) class) method)))
+                                  methods))
+              (selected-methods (cl-map 'vector
+                                        (lambda (choice) (alist-get choice menu-items nil nil 'equal))
+                                        (delete-dups
+                                         (completing-read-multiple "overridable methods: " menu-items))))
+              (params (list :overridableMethods selected-methods :context context)))
+    (lsp-bridge-call-file-api "jdtls_add_overridable_methods" (json-serialize params))))
+
+
 (provide 'lsp-bridge-jdtls)
 ;;; lsp-bridge-jdtls.el ends here

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -164,11 +164,6 @@ Setting this to nil or 0 will turn off the indicator."
   :type 'boolean
   :group 'lsp-bridge)
 
-(defcustom lsp-bridge-apply-edit-commands '("java.apply.workspaceEdit")
-  "Apply workspace edit if command match `lsp-bridge-apply-edit-commands', otherwise send workspace/executeCommand to LSP server."
-  :type 'cons
-  :group 'lsp-bridge)
-
 (defcustom lsp-bridge-lookup-doc-tooltip " *lsp-bridge-hover*"
   "Buffer for display hover information."
   :type 'string


### PR DESCRIPTION
- 重构 `lsp-bridge-code-action--fix-do`
- 新增 `lsp-bridge-code-action-command-handlers` 非标准lsp的code action command handler注册表
- 支持 jdtls `overrideMethodsPromptSupport`