### PR TITLE
Support byte compilation

### DIFF
--- a/acm/acm-backend-elisp.el
+++ b/acm/acm-backend-elisp.el
@@ -106,19 +106,17 @@
 (defvar acm-backend-elisp-symbols-update-size 0)
 
 (defun acm-backend-elisp-candidates (keyword)
-  (let* ((candidates (list)))
-    (when (and (acm-is-elisp-mode-p))
-      (dolist (elisp-symbol acm-backend-elisp-items)
-        (let ((symbol-type (acm-backend-elisp-symbol-type (intern elisp-symbol))))
-          (add-to-list 'candidates (list :key elisp-symbol
-                                         :icon symbol-type
-                                         :label elisp-symbol
-                                         :display-label elisp-symbol
-                                         :annotation (capitalize symbol-type)
-                                         :backend "elisp")
-                       t))))
-
-    candidates))
+  (when (and (acm-is-elisp-mode-p))
+    (mapcar
+     (lambda (elisp-symbol)
+       (let ((symbol-type (acm-backend-elisp-symbol-type (intern elisp-symbol))))
+         (list :key elisp-symbol
+               :icon symbol-type
+               :label elisp-symbol
+               :display-label elisp-symbol
+               :annotation (capitalize symbol-type)
+               :backend "elisp")))
+     acm-backend-elisp-items)))
 
 (defun acm-backend-elisp-candidate-doc (candidate)
   (let* ((symbol (intern (plist-get candidate :label)))

--- a/acm/acm-backend-search-file-words.el
+++ b/acm/acm-backend-search-file-words.el
@@ -97,17 +97,15 @@
 
 (defun acm-backend-search-file-words-candidates (keyword)
   (when acm-enable-search-file-words
-    (let* ((candidates (list)))
-      (dolist (candidate-label acm-backend-search-file-words-items)
-        (add-to-list 'candidates (list :key candidate-label
-                                       :icon "search"
-                                       :label candidate-label
-                                       :display-label candidate-label
-                                       :annotation "Search Word"
-                                       :backend "search-file-words")
-                     t))
-
-      candidates)))
+    (mapcar
+     (lambda (candidate-label)
+       (list :key candidate-label
+             :icon "search"
+             :label candidate-label
+             :display-label candidate-label
+             :annotation "Search Word"
+             :backend "search-file-words"))
+     acm-backend-search-file-words-items)))
 
 (defun acm-backend-search-file-words-candidate-expand (candidate-info bound-start)
   (if (acm-is-elisp-mode-p)

--- a/acm/acm-backend-tailwind.el
+++ b/acm/acm-backend-tailwind.el
@@ -91,17 +91,15 @@
 (defvar-local acm-backend-tailwind-items nil)
 
 (defun acm-backend-tailwind-candidates (keyword)
-  (let* ((candidates (list)))
-    (dolist (tailwind-symbol acm-backend-tailwind-items)
-      (add-to-list 'candidates (list :key tailwind-symbol
-                                     :icon "tailwind"
-                                     :label tailwind-symbol
-                                     :display-label tailwind-symbol
-                                     :annotation "Tailwind"
-                                     :backend "tailwind")
-                   t))
-
-    candidates))
+  (mapcar
+   (lambda (tailwind-symbol)
+     (list :key tailwind-symbol
+           :icon "tailwind"
+           :label tailwind-symbol
+           :display-label tailwind-symbol
+           :annotation "Tailwind"
+           :backend "tailwind"))
+   acm-backend-tailwind-items))
 
 (provide 'acm-backend-tailwind)
 

--- a/acm/acm-backend-telega.el
+++ b/acm/acm-backend-telega.el
@@ -47,12 +47,13 @@
                ))
     (if (string-equal keyword "")
         acm-backend-telega-items
-      (let ((candiates (list)))
-        (dolist (item acm-backend-telega-items)
-          (when (or (string-match keyword (plist-get item :label))
-                    (string-match keyword (plist-get item :annotation)))
-            (add-to-list 'candiates item)))
-        (acm-candidate-sort-by-prefix keyword candiates)))))
+      (acm-candidate-sort-by-prefix
+       keyword
+       (seq-filter
+        (lambda (item)
+          (or (string-match keyword (plist-get item :label))
+              (string-match keyword (plist-get item :annotation))))
+        acm-backend-telega-items)))))
 
 ;; Update userlist when first switch to telega buffer.
 (add-hook 'buffer-list-update-hook #'acm-backend-telega-update-items)

--- a/acm/acm-backend-tempel.el
+++ b/acm/acm-backend-tempel.el
@@ -17,19 +17,21 @@
 (defun acm-backend-tempel-candidates (keyword)
   (when (and acm-enable-tempel
              (featurep 'tempel))
-    (let* ((candidates (list))
-           (snippets (cl-loop for template in (tempel--templates)
+    (let* ((snippets (cl-loop for template in (tempel--templates)
                               collect (format "%s" (car template))))
            (match-snippets (seq-filter (lambda (s) (acm-candidate-fuzzy-search keyword s)) snippets)))
-      (dolist (snippet (cl-subseq match-snippets 0 (min (length match-snippets) acm-backend-tempel-candidates-number)))
-        (add-to-list 'candidates (list :key snippet
-                                       :icon "snippet"
-                                       :label snippet
-                                       :display-label snippet
-                                       :annotation "Tempel"
-                                       :backend "tempel")
-                     t))
-      (acm-candidate-sort-by-prefix keyword candidates))))
+      (acm-candidate-sort-by-prefix
+       keyword
+       (mapcar
+        (lambda (snippet)
+          (list :key snippet
+                :icon "snippet"
+                :label snippet
+                :display-label snippet
+                :annotation "Tempel"
+                :backend "tempel"))
+        (cl-subseq match-snippets 0 (min (length match-snippets) acm-backend-tempel-candidates-number)))
+       candidates))))
 
 (defun acm-backend-tempel-candidate-expand (candidate-info bound-start)
   (delete-region bound-start (point))

--- a/acm/acm-backend-yas.el
+++ b/acm/acm-backend-yas.el
@@ -172,8 +172,7 @@ Default matching use snippet filename."
       (setq acm-backend-yas--cache (yas--all-templates (yas--get-snippet-tables)))
       (setq acm-backend-yas--cache-expire-p nil)
       (setq acm-backend-yas--cache-modes (yas--modes-to-activate)))
-    (let* ((candidates (list))
-           (show-key acm-backend-yas-show-trigger-keyword)
+    (let* ((show-key acm-backend-yas-show-trigger-keyword)
            ;; WORKAROUND backward compatibility for boolean value
            (form (concat "%s" (or (and (booleanp show-key) show-key " (%s)") show-key)))
            (match-templates (acm-backend-yas--template-sort
@@ -184,23 +183,24 @@ Default matching use snippet filename."
                                             (car (acm-backend-yas--template-cons s))))
                                          acm-backend-yas--cache)))
            (limit (min (length match-templates) acm-backend-yas-candidates-number)))
-      (dolist (template (cl-subseq match-templates 0 limit))
-        (let* ((pair (acm-backend-yas--template-cons template))
-               (match (car pair))
-               (display (format form
-                                match
-                                (propertize (cdr pair)
-                                            'face
-                                            'acm-backend-yas-extra-info-face)))
-               (content (yas--template-content template)))
-          (add-to-list 'candidates (list :key match
-                                         :icon "snippet"
-                                         :label match
-                                         :display-label display
-                                         :content content
-                                         :annotation "Yas-Snippet"
-                                         :backend "yas") t)))
-      candidates)))
+      (mapcar
+       (lambda (template)
+         (let* ((pair (acm-backend-yas--template-cons template))
+                (match (car pair))
+                (display (format form
+                                 match
+                                 (propertize (cdr pair)
+                                             'face
+                                             'acm-backend-yas-extra-info-face)))
+                (content (yas--template-content template)))
+           (list :key match
+                 :icon "snippet"
+                 :label match
+                 :display-label display
+                 :content content
+                 :annotation "Yas-Snippet"
+                 :backend "yas")))
+       (cl-subseq match-templates 0 limit)))))
 
 (defun acm-backend-yas-candidate-expand (candidate bound-start)
   (delete-region bound-start (point))

--- a/lsp-bridge-ref.el
+++ b/lsp-bridge-ref.el
@@ -587,7 +587,7 @@ user more freedom to use rg with special arguments."
         (setq start (point))
         (setq filename (buffer-substring-no-properties start end))
         (end-of-line)
-        (add-to-list 'file-extensions (lsp-bridge-ref-file-extension filename))))
+        (push (lsp-bridge-ref-file-extension filename) file-extensions)))
     (if (< (length file-extensions) 2)
         (message (format "[LSP-Bridge] Has one type files now."))
       (setq filter-extension (ido-completing-read (if match-files

--- a/test/test_byte_compile.py
+++ b/test/test_byte_compile.py
@@ -1,0 +1,9 @@
+import unittest
+from glob import glob
+
+from test.common import *
+
+class ByteCompile(unittest.TestCase):
+    def test_byte_compile(self):
+        returncode = run_batch_sync(["-f", "batch-byte-compile"] + glob("acm/*.el") + glob("*.el"))
+        self.assertEqual(returncode, 0, 'Byte compilation failed')


### PR DESCRIPTION
Hi! I've been trying to [package this extension with Nix](https://github.com/kira-bruneau/home-config/blob/d7e88d71f076867dbef3a2b3d5f66e167d949624/package/emacs/package/lsp-bridge/default.nix) and I ran into some problems with byte compilation:

```
acm/acm-backend-yas.el:188:10: Error: ‘add-to-list’ can’t use lexical var ‘candidates’; use ‘push’ or ‘cl-pushnew’
acm/acm-backend-tempel.el:24:16: Error: ‘add-to-list’ can’t use lexical var ‘candidates’; use ‘push’ or ‘cl-pushnew’
acm/acm-backend-elisp.el:112:10: Error: ‘add-to-list’ can’t use lexical var ‘candidates’; use ‘push’ or ‘cl-pushnew’
acm/acm-backend-telega.el:52:18: Error: ‘add-to-list’ can’t use lexical var ‘candiates’; use ‘push’ or ‘cl-pushnew’
acm/acm-backend-search-file-words.el:101:16: Error: ‘add-to-list’ can’t use lexical var ‘candidates’; use ‘push’ or ‘cl-pushnew’
acm/acm-backend-tailwind.el:95:14: Error: ‘add-to-list’ can’t use lexical var ‘candidates’; use ‘push’ or ‘cl-pushnew’
acm/acm-backend-citre.el:195:16: Error: ‘add-to-list’ can’t use lexical var ‘candidates’; use ‘push’ or ‘cl-pushnew’
acm/acm.el:93:2: Error: Cannot open load file: No such file or directory, acm-icon
lsp-bridge-ref.el:585:8: Error: ‘add-to-list’ can’t use lexical var ‘file-extensions’; use ‘push’ or ‘cl-pushnew’
lsp-bridge-code-action.el:83:2: Error: Cannot open load file: No such file or directory, acm
lsp-bridge-diagnostic.el:83:2: Error: Cannot open load file: No such file or directory, acm
lsp-bridge.el:87:2: Error: Cannot open load file: No such file or directory, acm-frame
lsp-bridge-call-hierarchy.el:2:2: Error: Cannot open load file: No such file or directory, acm-frame
```

For the `add-to-list` errors I replaced `add-to-list` with `push`, `mapcon`, `mapcan`, and `seq-filter`, which got it working! A nice upside to this is now these loops run in $O(n)$ instead of $O(n^2)$ - I doubt the change in performance will be noticeable though :sweat_smile:

For the acm errors I pulled out the code that automatically adds acm to `load-path`, and updated all references to explicitly require adding acm to `load-path`. I think that's the right approach, but it's another step to add to your config, and I'm curious what you think.

I also thought it would be a good idea to add a new test to verify byte compilation. There are still warnings, but this PR gets through all the errors!

After getting this all set up, I've been really liking this package! Thanks for all the hard work! It _really_ makes a difference how you've designed things around a fast feedback loop 😊 