### PR TITLE
fix :type for defcustom variables which are lists

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -131,7 +131,7 @@
                                                     lsp-bridge-not-complete-manually
                                                     )
   "A list of predicate functions with no argument to enable popup completion in callback."
-  :type 'list
+  :type '(repeat function)
   :group 'lsp-bridge)
 
 (defcustom lsp-bridge-flash-line-delay .3
@@ -465,7 +465,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     markdown-mode-hook
     )
   "The default mode hook to enable lsp-bridge."
-  :type 'list)
+  :type '(repeat variable))
 
 (defcustom lsp-bridge-get-single-lang-server-by-project nil
   "Get lang server with project path and file path.")
@@ -1439,7 +1439,7 @@ So we build this macro to restore postion after code format."
 
 (defcustom lsp-bridge-org-babel-lang-list '("clojure" "latex" "python")
   "A list of org babel languages in which source code block lsp-bridge will be enabled."
-  :type 'list
+  :type '(repeat string)
   :group 'lsp-bridge)
 
 (defvar lsp-bridge-signature-help-timer nil)


### PR DESCRIPTION
When a `defcustom` variable is a list of arbitrary length, it
needs to be declared using `:type '(repeat ELEMENT-TYPE)` rather
than `:type 'list` as explained in the following chapter of the
elisp reference manual:

https://www.gnu.org/software/emacs/manual/html_node/elisp/Composite-Types.html