### PR TITLE
Fix detecting when refs are already filtered to a single extension

### DIFF
--- a/lsp-bridge-ref.el
+++ b/lsp-bridge-ref.el
@@ -587,7 +587,7 @@ user more freedom to use rg with special arguments."
         (setq start (point))
         (setq filename (buffer-substring-no-properties start end))
         (end-of-line)
-        (push (lsp-bridge-ref-file-extension filename) file-extensions)))
+        (cl-pushnew (lsp-bridge-ref-file-extension filename) file-extensions :test 'string-equal)))
     (if (< (length file-extensions) 2)
         (message (format "[LSP-Bridge] Has one type files now."))
       (setq filter-extension (ido-completing-read (if match-files


### PR DESCRIPTION
Oops I realized I introduced a breaking change in [#557](https://github.com/manateelazycat/lsp-bridge/pull/557/files#diff-fc1ce441eeb8d0c03fec0d0e34c34d18cf9271370450afe309f12a9a296580daR590). `file-extensions` should be treated as a set here, not a list.

This fixes detecting when the ref list has already been filtered down to a single extension.