### PR TITLE
Add elixir-ts-mode-hook to lsp-bridge-default-mode-hooks and to interpolation list

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -507,8 +507,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     json-ts-mode-hook
     python-ts-mode-hook
     bash-ts-mode-hook
-    typescript-ts-mode-hook
-    )
+    typescript-ts-mode-hook)
   "The default mode hook to enable lsp-bridge."
   :type '(repeat variable))
 

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -587,6 +587,8 @@ you can customize `lsp-bridge-get-workspace-folder' to return workspace folder p
     (sh-mode . "\$\{")
     (bash-mode . "\$\{")
     (bash-ts-mode . "\$\{")
+    (elixir-mode . "\#\{")
+    (elixir-ts-mode . "\#\{")
     ;; For #{}
     (ruby-mode . "\#\{")
     ;; For {{}}

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -501,6 +501,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     c-ts-mode-hook
     c++-ts-mode-hook
     cmake-ts-mode-hook
+    elixir-ts-mode-hook
     toml-ts-mode-hook
     css-ts-mode-hook
     js-ts-mode-hook


### PR DESCRIPTION
Sorry, missed this one. I tried adding heex-ts-mode, but the completion was a bit unpleasant as it returns mostly elixir, not heex suggestions.