### PR TITLE
remove previous org bable complete

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1932,35 +1932,6 @@ SymbolKind (defined in the LSP)."
   (lsp-bridge-try-completion))
 
 
-(cl-defmacro lsp-org-babel-enable (lang)
-  "Support LANG in org source code block."
-  (cl-check-type lang string)
-  (let* ((edit-pre (intern (format "org-babel-edit-prep:%s" lang)))
-         (intern-pre (intern (format "lsp--%s" (symbol-name edit-pre)))))
-    `(progn
-       (defun ,intern-pre (info)
-         (let ((file-name (->> info caddr (alist-get :file))))
-           (unless file-name
-             (setq file-name (concat default-directory ".org-src-babel"))
-             (write-region (point-min) (point-max) file-name))
-           (setq buffer-file-name file-name)
-           (lsp-bridge-mode 1)))
-       (put ',intern-pre 'function-documentation
-            (format "Enable lsp-bridge-mode in the buffer of org source block (%s)."
-                    (upcase ,lang)))
-       (if (fboundp ',edit-pre)
-           (advice-add ',edit-pre :after ',intern-pre)
-         (progn
-           (defun ,edit-pre (info)
-             (,intern-pre info))
-           (put ',edit-pre 'function-documentation
-                (format "Prepare local buffer environment for org source block (%s)."
-                        (upcase ,lang))))))))
-
-(with-eval-after-load 'org
-  (dolist (lang lsp-bridge-org-babel-lang-list)
-    (eval `(lsp-org-babel-enable ,lang))))
-
 ;;; support which-func-mode
 ;;;
 


### PR DESCRIPTION
Previous method is slow and buggy, which requires saving the block before each edit. We can use `lsp-bridge-enable-org-babel` with native lsp bridge support to achieve better performance.