### PR TITLE
some improvements for org babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ It should be noted that lsp-bridge has three scanning modes:
 * `lsp-bridge-python-command`: The path of the python command, if you use `conda`, you may customize this option. Windows platform using `python.exe` rather than `python3`, if lsp-bridge can't work, try set to `python3`
 * `lsp-bridge-complete-manually`: Only popup completion menu when user call `lsp-bridge-popup-complete-menu` command, default is nil
 * `lsp-bridge-get-workspace-folder`: You need to put multiple project in a `workspace` directory in Java before you can jump function defintion normally. This function can be customized, the function input is the project path and returns the `workspace` directory corresponding
-* `lsp-bridge-org-babel-lang-list`: list of language to support org-mode code block completion, need move cursor to code block and execute command `org-edit-special`, then lsp-bridge can show completion menu in popup window
+* `lsp-bridge-org-babel-lang-list`: list of language to support org-mode code block completion, nil enable all languages, default is nil
 * `lsp-bridge-enable-diagnostics`: code diagnostic, enable by default
 * `lsp-bridge-enable-hover-diagnostic`: show diagnostic tooltip when cursor hover diagnostic place, disable by default
 * `lsp-bridge-enable-search-words`: index the word of the file, enable by default

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,7 +110,7 @@ lsp-bridge 开箱即用， 安装好语言对应的[LSP 服务器](https://githu
 * `lsp-bridge-python-command`: Python 命令的路径, 如果你用 `conda`， 你也许会定制这个选项。 Windows 平台用的是 `python.exe` 而不是 `python3`, 如果 lsp-bridge 不能工作， 可以尝试改成 `python3`
 * `lsp-bridge-complete-manually`: 只有当用户手动调用 `lsp-bridge-popup-complete-menu` 命令的时候才弹出补全菜单， 默认关闭
 * `lsp-bridge-get-workspace-folder`: 在 Java 中需要把多个项目放到一个 Workspace 目录下， 才能正常进行定义跳转， 可以自定义这个函数， 函数输入是项目路径， 返回对应的 Workspace 目录
-* `lsp-bridge-org-babel-lang-list`: 支持 org-mode 代码块补全的语言列表, 需要先在代码块调用命令 `org-edit-special`， 在弹出窗口 lsp-bridge 才能提供补全
+* `lsp-bridge-org-babel-lang-list`: 支持 org-mode 代码块补全的语言列表，默认nil对于所有语言使用
 * `lsp-bridge-enable-diagnostics`: 代码诊断， 默认打开
 * `lsp-bridge-enable-hover-diagnostic`: 光标移动到错误位置弹出诊断信息， 默认关闭
 * `lsp-bridge-enable-search-words`: 索引打开文件的单词， 默认打开

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -759,21 +759,20 @@ So we build this macro to restore postion after code format."
 (defun lsp-bridge-check-org-babel-lsp-server ()
   "Check if current point is in org babel block. "
   (if (and lsp-bridge--org-babel-block-bop lsp-bridge--org-babel-block-eop lsp-bridge--org-babel-info-cache
-           (> (point) lsp-bridge--org-babel-block-bop) (< (point) lsp-bridge--org-babel-block-eop))
+           (>= (point) lsp-bridge--org-babel-block-bop) (<= (point) lsp-bridge--org-babel-block-eop))
       lsp-bridge--org-babel-info-cache
     (setq-local lsp-bridge--org-babel-info-cache (org-element-context))
-    (unless (eq (org-element-type lsp-bridge--org-babel-info-cache) 'src-block)
-      (setq-local lsp-bridge--org-babel-info-cache nil))
-    (when lsp-bridge--org-babel-info-cache
-      (setq-local lsp-bridge--org-babel-block-bop (org-element-property :begin lsp-bridge--org-babel-info-cache))
-      (setq-local lsp-bridge--org-babel-block-eop (org-element-property :end lsp-bridge--org-babel-info-cache))
+    (if (not (eq (org-element-type lsp-bridge--org-babel-info-cache) 'src-block))
+        (setq-local lsp-bridge--org-babel-info-cache nil)
+      (save-excursion
+        (goto-char (org-element-property :begin lsp-bridge--org-babel-info-cache))
+        (setq-local lsp-bridge--org-babel-block-bop (1+ (point-at-eol))))
+      (setq-local lsp-bridge--org-babel-block-eop (+ lsp-bridge--org-babel-block-bop
+                                                     (length (org-element-property :value lsp-bridge--org-babel-info-cache))))
       ;; sync it in `lsp-bridge-monitor-before-change'
       (setq-local lsp-bridge--org-update-file-before-change t)))
 
   (and lsp-bridge--org-babel-info-cache
-       ;; not send change-file for begin_src and end_src
-       (not (string-match-p "^[[:space:]]*#\\+"
-                            (buffer-substring-no-properties (point-at-bol) (point-at-eol))))
        (lsp-bridge-get-single-lang-server-by-mode)))
 
 (defun lsp-bridge-has-lsp-server-p ()
@@ -1156,7 +1155,7 @@ So we build this macro to restore postion after code format."
                lsp-bridge--org-update-file-before-change)
       (setq-local lsp-bridge--org-update-file-before-change nil)
       (lsp-bridge-call-file-api "update_file" (buffer-name)
-                                (line-number-at-pos lsp-bridge--org-babel-block-bop)))
+                                (1- (line-number-at-pos lsp-bridge--org-babel-block-bop))))
 
     (setq-local lsp-bridge--before-change-begin-pos (lsp-bridge--point-position begin))
     (setq-local lsp-bridge--before-change-end-pos (lsp-bridge--point-position end))))
@@ -1581,11 +1580,6 @@ So we build this macro to restore postion after code format."
     ))
 
 (defvar lsp-bridge-mode-map (make-sparse-keymap))
-
-(defcustom lsp-bridge-org-babel-lang-list '("clojure" "latex" "python")
-  "A list of org babel languages in which source code block lsp-bridge will be enabled."
-  :type '(repeat string)
-  :group 'lsp-bridge)
 
 (defvar lsp-bridge-signature-help-timer nil)
 

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -392,6 +392,10 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
 (defcustom lsp-bridge-enable-org-babel nil
   "Use `lsp-bridge' in org-babel, default is disable.")
 
+(defcustom lsp-bridge-org-babel-lang-list nil
+  "A list of org babel languages like (\"python\" \"bash\"), which enable lsp-bridge. if nil means enable all languages."
+  :type '(repeat string))
+
 (defcustom lsp-bridge-complete-manually nil
   "Only popup completion menu when user call `lsp-bridge-popup-complete-menu' command.")
 
@@ -749,11 +753,14 @@ So we build this macro to restore postion after code format."
             (lsp-bridge-enable-org-babel
              ;; get lang server according to org babel
              (let* ((lang (org-element-property :language lsp-bridge--org-babel-info-cache))
-                    (mode-name (concat (symbol-name (cdr (assoc lang org-src-lang-modes))) "-mode"))
+                    (lang-name (symbol-name (cdr (assoc lang org-src-lang-modes))))
+                    (mode-name (concat lang-name "-mode"))
                     (major-mode (intern mode-name)))
-               (if (eq major-mode 'emacs-lisp-mode)
-                   (setq-local acm-is-elisp-mode-in-org t))
-               (lsp-bridge-get-single-lang-server-by-mode))))))))
+               (setq-local acm-is-elisp-mode-in-org (eq major-mode 'emacs-lisp-mode))
+               ;; if `lsp-bridge-org-babel-lang-list' is set, only enable lsp when lang in it
+               (when (or (eq lsp-bridge-org-babel-lang-list nil)
+                         (member lang-name lsp-bridge-org-babel-lang-list))
+                 (lsp-bridge-get-single-lang-server-by-mode)))))))))
 
 (defvar-local lsp-bridge--org-update-file-before-change nil)
 (defun lsp-bridge-check-org-babel-lsp-server ()


### PR DESCRIPTION
1. support `lsp-bridge-org-babel-lang-list` in lsp-bridge

2. remove begin_src and end_src when check org babel border