### PR TITLE
feat: add support for more treesit mode

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -497,17 +497,23 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     kotlin-mode-hook
     vhdl-mode-hook
 
-    c-ts-mode-hook
-    c++-ts-mode-hook
-    cmake-ts-mode-hook
-    elixir-ts-mode-hook
-    toml-ts-mode-hook
-    css-ts-mode-hook
-    js-ts-mode-hook
-    json-ts-mode-hook
-    python-ts-mode-hook
-    bash-ts-mode-hook
-    typescript-ts-mode-hook)
+		js-ts-mode
+		c-ts-mode
+		yaml-ts-mode
+		css-ts-mode
+		csharp-ts-mode
+		dockerfile-ts-mode
+		bash-ts-mode
+		ruby-ts-mode
+		java-ts-mode
+		python-ts-mode
+		typescript-ts-mode
+		go-mod-ts-mode
+		cmake-ts-mode
+		c++-ts-mode
+		json-ts-mode
+		go-ts-mode
+		rust-ts-mode)
   "The default mode hook to enable lsp-bridge."
   :type '(repeat variable))
 


### PR DESCRIPTION
the updated ts-mode list comes from the builtin ts-modes in the latest emacs29, and only chooses those languages supported by lsp-bridge