### PR TITLE
do not use treesitter if no parser available

### DIFF
--- a/acm/acm.el
+++ b/acm/acm.el
@@ -1058,7 +1058,7 @@ The key of candidate will change between two LSP results."
           )))))
 
 (defun acm-in-string-p (&optional state)
-  (if (featurep 'treesit)
+  (if (and (featurep 'treesit) (treesit-parser-list))
       ;; Avoid use `acm-current-parse-state' when treesit is enable.
       ;; `beginning-of-defun' is very expensive function will slow down completion menu.
       ;; We use `treesit-node-type' directly if treesit is enable.

--- a/acm/acm.el
+++ b/acm/acm.el
@@ -1044,7 +1044,7 @@ The key of candidate will change between two LSP results."
     (setq acm-markdown-render-doc doc)))
 
 (defun acm-in-comment-p (&optional state)
-  (if (featurep 'treesit)
+  (if (and (featurep 'treesit) (treesit-parser-list))
       ;; Avoid use `acm-current-parse-state' when treesit is enable.
       ;; `beginning-of-defun' is very expensive function will slow down completion menu.
       ;; We use `treesit-node-type' directly if treesit is enable.


### PR DESCRIPTION
lsp bridge is enabled in markdown mode. On switching to markdown mode in magit (`forge-edit-post`), acm tries to determine what's the character type at point using treesitter in emacs 29 but failed because it does not know the language and there is no parser available

```
Debugger entered--Lisp error: (treesit-no-parser #<buffer 77>)
  treesit-buffer-root-node(nil)
  treesit-node-at(1)
  (treesit-node-type (treesit-node-at (point)))
  (string-equal (treesit-node-type (treesit-node-at (point))) "string")
  (if (featurep 'treesit) (string-equal (treesit-node-type (treesit-node-at (point))) "string") (condition-case nil (progn (if (or (bobp) (eobp)) nil (save-excursion (and (nth 3 (or state ...)) (not (equal ... ...)))))) (error nil)))
  acm-in-string-p()
  (if (acm-in-string-p) (let* ((filename (and t (thing-at-point 'filename t))) (dirname (and filename (condition-case nil (progn (expand-file-name ...)) (error nil))))) (if dirname (if (lsp-bridge-is-remote-file) (lsp-bridge-remote-send-func-request "search_paths_search" (list dirname (file-name-base filename))) (if (file-exists-p dirname) (progn (lsp-bridge-call-async "search_paths_search" dirname (file-name-base filename))))))) (set (make-local-variable 'acm-backend-path-items) nil))
  (let* ((current-word (thing-at-point 'word t)) (current-symbol (thing-at-point 'symbol t))) (if acm-enable-tabnine (progn (lsp-bridge-tabnine-complete))) (if acm-enable-search-sdcv-words (progn (if (or (string-equal current-word "") (null current-word)) nil (lsp-bridge-call-async "search_sdcv_words_search" current-word)))) (lsp-bridge-elisp-symbols-search current-symbol) (if lsp-bridge-prohibit-completion nil (if (or buffer-file-name (lsp-bridge-is-remote-file)) (progn (let ((current-word (acm-backend-search-file-words-get-point-string))) (if (or (string-equal current-word "") (null current-word)) nil (if (lsp-bridge-is-remote-file) (lsp-bridge-remote-send-func-request "search_file_words_search" ...) (lsp-bridge-call-async "search_file_words_search" current-word))))))) (if (and (derived-mode-p 'web-mode) (acm-in-string-p) (save-excursion (search-backward-regexp "class=" (point-at-bol) t))) (progn (if (or (string-equal current-symbol "") (null current-symbol)) nil (if (lsp-bridge-is-remote-file) (lsp-bridge-remote-send-func-request "search_tailwind_keywords_search" (list lsp-bridge-remote-file-path current-symbol)) (lsp-bridge-call-async "search_tailwind_keywords_search" buffer-file-name current-symbol))))) (if (acm-in-string-p) (let* ((filename (and t (thing-at-point 'filename t))) (dirname (and filename (condition-case nil (progn ...) (error nil))))) (if dirname (if (lsp-bridge-is-remote-file) (lsp-bridge-remote-send-func-request "search_paths_search" (list dirname (file-name-base filename))) (if (file-exists-p dirname) (progn (lsp-bridge-call-async "search_paths_search" dirname ...)))))) (set (make-local-variable 'acm-backend-path-items) nil)))
  (progn (let* ((current-word (thing-at-point 'word t)) (current-symbol (thing-at-point 'symbol t))) (if acm-enable-tabnine (progn (lsp-bridge-tabnine-complete))) (if acm-enable-search-sdcv-words (progn (if (or (string-equal current-word "") (null current-word)) nil (lsp-bridge-call-async "search_sdcv_words_search" current-word)))) (lsp-bridge-elisp-symbols-search current-symbol) (if lsp-bridge-prohibit-completion nil (if (or buffer-file-name (lsp-bridge-is-remote-file)) (progn (let ((current-word ...)) (if (or ... ...) nil (if ... ... ...)))))) (if (and (derived-mode-p 'web-mode) (acm-in-string-p) (save-excursion (search-backward-regexp "class=" (point-at-bol) t))) (progn (if (or (string-equal current-symbol "") (null current-symbol)) nil (if (lsp-bridge-is-remote-file) (lsp-bridge-remote-send-func-request "search_tailwind_keywords_search" (list lsp-bridge-remote-file-path current-symbol)) (lsp-bridge-call-async "search_tailwind_keywords_search" buffer-file-name current-symbol))))) (if (acm-in-string-p) (let* ((filename (and t (thing-at-point ... t))) (dirname (and filename (condition-case nil ... ...)))) (if dirname (if (lsp-bridge-is-remote-file) (lsp-bridge-remote-send-func-request "search_paths_search" (list dirname ...)) (if (file-exists-p dirname) (progn ...))))) (set (make-local-variable 'acm-backend-path-items) nil))))
  (if (and (lsp-bridge-epc-live-p lsp-bridge-epc-process) (not (and (or (string-prefix-p "org-" this-command-string) (string-prefix-p "+org/" this-command-string)) (not (string-equal this-command-string "org-self-insert-command"))))) (progn (let* ((current-word (thing-at-point 'word t)) (current-symbol (thing-at-point 'symbol t))) (if acm-enable-tabnine (progn (lsp-bridge-tabnine-complete))) (if acm-enable-search-sdcv-words (progn (if (or (string-equal current-word "") (null current-word)) nil (lsp-bridge-call-async "search_sdcv_words_search" current-word)))) (lsp-bridge-elisp-symbols-search current-symbol) (if lsp-bridge-prohibit-completion nil (if (or buffer-file-name (lsp-bridge-is-remote-file)) (progn (let (...) (if ... nil ...))))) (if (and (derived-mode-p 'web-mode) (acm-in-string-p) (save-excursion (search-backward-regexp "class=" (point-at-bol) t))) (progn (if (or (string-equal current-symbol "") (null current-symbol)) nil (if (lsp-bridge-is-remote-file) (lsp-bridge-remote-send-func-request "search_tailwind_keywords_search" ...) (lsp-bridge-call-async "search_tailwind_keywords_search" buffer-file-name current-symbol))))) (if (acm-in-string-p) (let* ((filename (and t ...)) (dirname (and filename ...))) (if dirname (if (lsp-bridge-is-remote-file) (lsp-bridge-remote-send-func-request "search_paths_search" ...) (if ... ...)))) (set (make-local-variable 'acm-backend-path-items) nil)))))
  (let ((this-command-string (format "%s" this-command))) (setq lsp-bridge-last-change-command (format "%s" this-command)) (setq lsp-bridge-last-change-position (list (current-buffer) (buffer-chars-modified-tick) (point))) (lsp-bridge-org-babel-monitor-after-change begin end length) (if (lsp-bridge-call-file-api-p) (progn (lsp-bridge-call-file-api "change_file" lsp-bridge--before-change-begin-pos lsp-bridge--before-change-end-pos length (buffer-substring-no-properties begin end) (lsp-bridge--position) (acm-char-before) (buffer-name) (acm-get-input-prefix)))) (if (and (lsp-bridge-epc-live-p lsp-bridge-epc-process) (not (and (or (string-prefix-p "org-" this-command-string) (string-prefix-p "+org/" this-command-string)) (not (string-equal this-command-string "org-self-insert-command"))))) (progn (let* ((current-word (thing-at-point 'word t)) (current-symbol (thing-at-point 'symbol t))) (if acm-enable-tabnine (progn (lsp-bridge-tabnine-complete))) (if acm-enable-search-sdcv-words (progn (if (or ... ...) nil (lsp-bridge-call-async "search_sdcv_words_search" current-word)))) (lsp-bridge-elisp-symbols-search current-symbol) (if lsp-bridge-prohibit-completion nil (if (or buffer-file-name (lsp-bridge-is-remote-file)) (progn (let ... ...)))) (if (and (derived-mode-p 'web-mode) (acm-in-string-p) (save-excursion (search-backward-regexp "class=" ... t))) (progn (if (or ... ...) nil (if ... ... ...)))) (if (acm-in-string-p) (let* ((filename ...) (dirname ...)) (if dirname (if ... ... ...))) (set (make-local-variable 'acm-backend-path-items) nil))))))
  (if lsp-bridge-revert-buffer-flag nil (let ((this-command-string (format "%s" this-command))) (setq lsp-bridge-last-change-command (format "%s" this-command)) (setq lsp-bridge-last-change-position (list (current-buffer) (buffer-chars-modified-tick) (point))) (lsp-bridge-org-babel-monitor-after-change begin end length) (if (lsp-bridge-call-file-api-p) (progn (lsp-bridge-call-file-api "change_file" lsp-bridge--before-change-begin-pos lsp-bridge--before-change-end-pos length (buffer-substring-no-properties begin end) (lsp-bridge--position) (acm-char-before) (buffer-name) (acm-get-input-prefix)))) (if (and (lsp-bridge-epc-live-p lsp-bridge-epc-process) (not (and (or (string-prefix-p "org-" this-command-string) (string-prefix-p "+org/" this-command-string)) (not (string-equal this-command-string "org-self-insert-command"))))) (progn (let* ((current-word (thing-at-point ... t)) (current-symbol (thing-at-point ... t))) (if acm-enable-tabnine (progn (lsp-bridge-tabnine-complete))) (if acm-enable-search-sdcv-words (progn (if ... nil ...))) (lsp-bridge-elisp-symbols-search current-symbol) (if lsp-bridge-prohibit-completion nil (if (or buffer-file-name ...) (progn ...))) (if (and (derived-mode-p ...) (acm-in-string-p) (save-excursion ...)) (progn (if ... nil ...))) (if (acm-in-string-p) (let* (... ...) (if dirname ...)) (set (make-local-variable ...) nil)))))))
  lsp-bridge-monitor-after-change(1 1 2)
  forge-edit-post()
  funcall-interactively(forge-edit-post)
  command-execute(forge-edit-post)
```