### PR TITLE
improve the candidates compare logic for candidates with same sortTex…

### DIFF
--- a/core/handler/completion.py
+++ b/core/handler/completion.py
@@ -44,23 +44,33 @@ class Completion(Handler):
         prefix = self.prefix.lower()
         x_label : str = x["label"].lower()
         y_label : str = y["label"].lower()
+        x_icon : str = x["icon"]
+        y_icon : str = y["icon"]
         x_sort_text : str = self.parse_sort_value(x["sortText"])
         y_sort_text : str = self.parse_sort_value(y["sortText"])
         x_include_prefix = x_label.startswith(prefix)
         y_include_prefix = y_label.startswith(prefix)
-        
+        x_method_name = x_label.split('(')[0]
+        y_method_name = y_label.split('(')[0]
+
         # 1. Sort file by sortText, sortText is provided by LSP server.
-        if x_sort_text != "" and y_sort_text != "":
+        if x_sort_text != "" and y_sort_text != "" and x_sort_text != y_sort_text:
             if x_sort_text < y_sort_text:
                 return -1
-            else:
+            elif x_sort_text > y_sort_text:
                 return 1
         # 2. Sort by prefix.
         elif x_include_prefix and not y_include_prefix:
             return -1
         elif y_include_prefix and not x_include_prefix:
             return 1
-        # 3. Sort by length.
+        # 3. Sort by method name if both candidates are method.
+        elif x_icon == "method" and y_icon == "method" and x_method_name != y_method_name:
+            if x_method_name < y_method_name:
+                return -1
+            elif x_method_name > y_method_name:
+                return 1
+        # 4. Sort by length.
         elif len(x_label) < len(y_label):
             return -1
         elif len(x_label) > len(y_label):


### PR DESCRIPTION
在JAVA(jdtls)下有下面两个问题
1. 同一类(variable/method)的sortText是相同的，原代码中没考虑相同的情况（导致排序结果看起来是无序的）
2. Java有方法重载，method之间的compre需先按method name(而不是完整label）比较，method name相同的情况下才进行完整label的比较（现在完整label的比较是按长度，重载方法排序后会分散开）