### PR TITLE
fix logic for getting Codeium version

### DIFF
--- a/lsp-bridge-lsp-installer.el
+++ b/lsp-bridge-lsp-installer.el
@@ -268,7 +268,7 @@ Only useful on GNU/Linux.  Automatically set if NixOS is detected."
          (version (with-current-buffer (url-retrieve-synchronously "https://api.github.com/repos/Exafunction/codeium/releases/latest")
                     (re-search-forward "^{")
                     (goto-char (1- (point)))
-                    (substring (gethash "name" (json-parse-buffer)) (length "language-server-v"))))
+                    (substring (gethash "name" (json-parse-buffer)) (length "codeium-enterprise-v"))))
          (file-name (format "language_server_%s_%s.%s"
                             platform
                             arch


### PR DESCRIPTION
https://api.github.com/repos/Exafunction/codeium/releases/latest 返回值变了。
```
...
  "node_id": "RE_kwDOIoT6Vc4GGNe-",
  "tag_name": "codeium-enterprise-v1.2.16",
  "target_commitish": "main",
  "name": "codeium-enterprise-v1.2.16",
  "draft": false,
  "prerelease": false,
  "created_at": "2023-01-03T20:26:02Z",
  "published_at": "2023-05-09T04:28:02Z",
...
```