### PR TITLE
Send response after lsp workspace/applyEdit eval in emacs.

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -635,6 +635,7 @@ class LspServer:
                         self.handle_workspace_configuration_request(message["method"], message["id"], message["params"])
                     elif message["method"] == "workspace/applyEdit":
                         eval_in_emacs("lsp-bridge-workspace-apply-edit", message["params"]["edit"])
+                        self.sender.send_response(message["id"], { "applied", True })
 
     def close_file(self, filepath):
         # Send didClose notification when client close file.


### PR DESCRIPTION
Fix lsp server (i.e. gopls ) not respond requests issue after lsp-bridge-code-action. Send { "applied": True } to lsp server after received workspace/applyEdit request and eval in emacs.