### PR TITLE
Add fallback functions for searching def/ref

### DIFF
--- a/core/handler/find_define.py
+++ b/core/handler/find_define.py
@@ -9,11 +9,12 @@ class FindDefine(Handler):
     cancel_on_change = True
 
     def process_request(self, position) -> dict:
+        self.pos = position
         return dict(position=position)
 
     def process_response(self, response: Union[dict, list]) -> None:
         if not response:
-            message_emacs("No definition found.")
+            eval_in_emacs("lsp-bridge-find-def-fallback", self.pos)
             return
 
         file_info = response[0] if isinstance(response, list) else response

--- a/core/handler/find_references.py
+++ b/core/handler/find_references.py
@@ -12,6 +12,7 @@ class FindReferences(Handler):
     method = "textDocument/references"
 
     def process_request(self, position) -> dict:
+        self.pos = position
         return dict(
             position=position,
             context=dict(includeDeclaration=False)
@@ -19,7 +20,7 @@ class FindReferences(Handler):
 
     def process_response(self, response: dict) -> None:
         if response is None:
-            message_emacs("No references found")
+            eval_in_emacs("lsp-bridge-find-ref-fallback", self.pos)
         else:
             references_dict = {}
             for uri_info in response:
@@ -49,4 +50,4 @@ class FindReferences(Handler):
 
             linecache.clearcache()  # clear line cache
 
-            eval_in_emacs("lsp-bridge-references--popup", references_content, references_counter)
+            eval_in_emacs("lsp-bridge-references--popup", references_content, references_counter, self.pos)

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1440,6 +1440,16 @@ So we build this macro to restore postion after code format."
 (defun lsp-bridge-monitor-after-save ()
   (lsp-bridge-call-file-api "save_file" (buffer-name)))
 
+(defcustom lsp-bridge-find-def-fallback-function nil
+  "Fallback for find definition failure."
+  :type 'function
+  :group 'lsp-bridge)
+
+(defcustom lsp-bridge-find-ref-fallback-function nil
+  "Fallback for find referecences failure."
+  :type 'function
+  :group 'lsp-bridge)
+
 (defvar-local lsp-bridge-jump-to-def-in-other-window nil)
 
 (defun lsp-bridge-find-def ()
@@ -1501,12 +1511,22 @@ So we build this macro to restore postion after code format."
   (interactive)
   (lsp-bridge-call-file-api "find_references" (lsp-bridge--position)))
 
-(defun lsp-bridge-references--popup (references-content references-counter)
+(defun lsp-bridge-find-def-fallback (position)
+  (message "[LSP-Bridge] No definition found.")
+  (if (functionp lsp-bridge-find-def-fallback-function)
+      (funcall lsp-bridge-find-def-fallback-function position)))
+
+(defun lsp-bridge-find-ref-fallback (position)
+  (message "[LSP-Bridge] No references found.")
+  (if (functionp lsp-bridge-find-ref-fallback-function)
+      (funcall lsp-bridge-find-ref-fallback-function position)))
+
+(defun lsp-bridge-references--popup (references-content references-counter position)
   (if (> references-counter 0)
       (progn
         (lsp-bridge-ref-popup references-content references-counter)
         (message "[LSP-Bridge] Found %s references" references-counter))
-    (message "[LSP-Bridge] No references found.")))
+    (lsp-bridge-find-ref-fallback position)))
 
 (defun lsp-bridge-rename ()
   (interactive)


### PR DESCRIPTION
It will be possible to intergrate lsp-bridge with other packages. 
In my case, I will try to find with tags backend when lsp failed to find def/ref.