### PR TITLE
Fix for rename-file-advisor renaming current file accidentally

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -2066,11 +2066,14 @@ SymbolKind (defined in the LSP)."
   (evil-add-command-properties #'lsp-bridge-find-impl :jump t))
 
 (defun lsp-bridge--rename-file-advisor (orig-fun &optional arg &rest args)
-  (let ((current-file-name (expand-file-name (buffer-file-name)))
-        (new-name (expand-file-name (nth 0 args))))
+  (let* ((current-file-name (buffer-file-name))
+         (current-file-name (and current-file-name
+                                 (expand-file-name current-file-name)))
+         (new-name (expand-file-name (nth 0 args))))
     (when (and lsp-bridge-mode
                (boundp 'acm-backend-lsp-filepath)
-               (file-equal-p current-file-name new-name))
+               current-file-name
+               (string-equal current-file-name new-name))
       (lsp-bridge-call-file-api "rename_file" new-name)
       (if (lsp-bridge-is-remote-file)
           (lsp-bridge-remote-send-func-request "close_file" (list acm-backend-lsp-filepath))

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -2066,9 +2066,11 @@ SymbolKind (defined in the LSP)."
   (evil-add-command-properties #'lsp-bridge-find-impl :jump t))
 
 (defun lsp-bridge--rename-file-advisor (orig-fun &optional arg &rest args)
-  (when (and lsp-bridge-mode
-             (boundp 'acm-backend-lsp-filepath))
-    (let ((new-name (expand-file-name (nth 0 args))))
+  (let ((current-file-name (expand-file-name (buffer-file-name)))
+        (new-name (expand-file-name (nth 0 args))))
+    (when (and lsp-bridge-mode
+               (boundp 'acm-backend-lsp-filepath)
+               (file-equal-p current-file-name new-name))
       (lsp-bridge-call-file-api "rename_file" new-name)
       (if (lsp-bridge-is-remote-file)
           (lsp-bridge-remote-send-func-request "close_file" (list acm-backend-lsp-filepath))


### PR DESCRIPTION
This is a fix for #659 