### PR TITLE
Support for async telega--searchChatMembers in the telega 0.8.162

### DIFF
--- a/acm/acm-backend-telega.el
+++ b/acm/acm-backend-telega.el
@@ -11,36 +11,70 @@
   :type 'boolean
   :group 'acm-backend-telega)
 
-(defvar-local acm-backend-telega-items nil)
+(defvar-local acm-backend-telega-items 'fetch
+  "List of loaded items.
+Number if async request has been made, but request is not yet completed.
+`fetch' if members has not yet been fetched.")
 
-(defun acm-backend-telega-fetch-members ()
-  "Fetch the current chat buffer members."
-  (let ((members (telega--searchChatMembers (telega-chatbuf--chat (current-buffer)) nil nil :limit (* 20 10000))))
-    (when members
-      (cl-remove-if (lambda (user) (string-empty-p (plist-get user :username))) members))))
+(defun acm-backend-telega-enabled-p ()
+  "Return non-nil if lsp-bridge is enabled in telega chatbufs."
+  (and lsp-bridge-mode acm-enable-telega (derived-mode-p 'telega-chat-mode)))
 
-(defun acm-backend-telega-update-items ()
+(defun acm-backend-telega-items-set (members)
+  "Callback for the `telega--searchChatMembers'.
+Sets `acm-backend-telega-items' for the current chatbuf."
+  (cl-assert (acm-backend-telega-enabled-p))
+  (setq acm-backend-telega-items
+        (mapcar (lambda (user)
+                  (let ((username (telega-msg-sender-username user))
+                        ;; TODO: support images/faces in the
+                        ;; lsp-bridge completion popup, so title with
+                        ;; avatars, badges and faces could be used
+                        (title (telega-msg-sender-title user
+                                 :with-avatar-p nil
+                                 :with-badges-p nil
+                                 :with-title-faces-p nil)))
+                    (list :key username
+                          :icon "at"
+                          :label username
+                          :display-label username
+                          :annotation title
+                          :backend "telega")))
+                ;; NOTE: only members having username are
+                ;; supported for lsp-bridge completion
+                ;; TODO: support for members without username, as in
+                ;; `telega-company-username' company backend
+                (cl-remove-if-not #'telega-msg-sender-username members)))
+  (message "Fetch telega userlist... done."))
+
+(defun acm-backend-telega-update-items (&optional _args)
   "Update the optional items."
   ;; Scoped by current line: the @ character must be present before the cursor
-  (when (and acm-enable-telega (eq major-mode 'telega-chat-mode))
-    (unless acm-backend-telega-items
-      (message "Fetch telega userlist...")
-      (setq-local acm-backend-telega-items
-                  (mapcar (lambda (user)
-                            (let ((username (plist-get user :username))
-                                  (firstname (plist-get user :first_name)))
-                              (list :key username
-                                    :icon "at"
-                                    :label username
-                                    :display-label username
-                                    :annotation firstname
-                                    :backend "telega")))
-                          (acm-backend-telega-fetch-members)))
-      (message "Fetch telega userlist done."))))
+  (when (acm-backend-telega-enabled-p)
+    (cond ((version< telega-version "0.8.162")
+           (message "telega: Update your telega to support lsp-bridge"))
+          ((eq acm-backend-telega-items 'fetch)
+           (let ((chat telega-chatbuf--chat))
+             (cl-assert chat)
+             (setq acm-backend-telega-items
+                   ;; NOTE: fetching members for channels is available
+                   ;; only for admins (from TDLib docs)
+                   (when (telega-chat-match-p chat '(or (not (type channel))
+                                                        (me-is-owner or-admin)))
+                     (message "Fetch telega userlist...")
+                     ;; TODO: possibly use "chatMembersFilterMention"
+                     ;; member filter, because chat might be filtering
+                     ;; messages by topic, see
+                     ;; `telega-company-username' for details
+                     (telega--searchChatMembers chat "" nil
+                       :callback
+                       (lambda (members)
+                         (with-telega-chatbuf chat
+                           (acm-backend-telega-items-set members))))))))
+          )))
 
 (defun acm-backend-telega-candidates (keyword)
-  (when (and acm-enable-telega
-             (eq major-mode 'telega-chat-mode)
+  (when (and (acm-backend-telega-enabled-p)
              (save-excursion
                (backward-char (length keyword))
                (= (char-before) ?@)
@@ -56,7 +90,8 @@
         acm-backend-telega-items)))))
 
 ;; Update userlist when first switch to telega buffer.
-(add-hook 'buffer-list-update-hook #'acm-backend-telega-update-items)
+(advice-add 'telega-chatbuf--switch-in
+            :after #'acm-backend-telega-update-items)
 
 (provide 'acm-backend-telega)
 ;;; acm-backend-telega.el ends here

--- a/acm/acm-backend-telega.el
+++ b/acm/acm-backend-telega.el
@@ -47,7 +47,7 @@ Sets `acm-backend-telega-items' for the current chatbuf."
                 (cl-remove-if-not #'telega-msg-sender-username members)))
   (message "Fetch telega userlist... done."))
 
-(defun acm-backend-telega-update-items (&optional _args)
+(defun acm-backend-telega-update-items (&rest _args)
   "Update the optional items."
   ;; Scoped by current line: the @ character must be present before the cursor
   (when (acm-backend-telega-enabled-p)


### PR DESCRIPTION
Current implementation for username completion in telega have few issues:
1. It has  sync variant of fetching member list, because telega does not provide async API to fetch chat members
2. It uses potentially dangerous `buffer-list-update-hook` to do the job
3. It does some  job even if `lsp-bridge-mode` is disabled

This commit tries to resolve all these issues