### PR TITLE
Add support for `clojure*-ts-mode`

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -428,8 +428,7 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     (tuareg-mode .                                                               "ocamllsp")
     (erlang-mode .                                                               "erlang-ls")
     ((latex-mode Tex-latex-mode texmode context-mode texinfo-mode bibtex-mode) . lsp-bridge-tex-lsp-server)
-    ((clojure-mode clojurec-mode clojurescript-mode clojurex-mode clojure-ts-mode
-     clojurec-ts-mode clojurescript-ts-mode clojure-dart-ts-mode)) .             "clojure-lsp")
+    ((clojure-mode clojurec-mode clojurescript-mode clojurex-mode clojure-ts-mode clojurec-ts-mode clojurescript-ts-mode clojure-dart-ts-mode) . "clojure-lsp")
     ((sh-mode bash-mode bash-ts-mode) .                                          "bash-language-server")
     ((css-mode css-ts-mode) .                                                    "vscode-css-language-server")
     (elm-mode   .                                                                "elm-language-server")

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -428,7 +428,8 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     (tuareg-mode .                                                               "ocamllsp")
     (erlang-mode .                                                               "erlang-ls")
     ((latex-mode Tex-latex-mode texmode context-mode texinfo-mode bibtex-mode) . lsp-bridge-tex-lsp-server)
-    ((clojure-mode clojurec-mode clojurescript-mode clojurex-mode) .             "clojure-lsp")
+    ((clojure-mode clojurec-mode clojurescript-mode clojurex-mode clojure-ts-mode
+     clojurec-ts-mode clojurescript-ts-mode clojure-dart-ts-mode)) .             "clojure-lsp")
     ((sh-mode bash-mode bash-ts-mode) .                                          "bash-language-server")
     ((css-mode css-ts-mode) .                                                    "vscode-css-language-server")
     (elm-mode   .                                                                "elm-language-server")
@@ -488,6 +489,10 @@ Then LSP-Bridge will start by gdb, please send new issue with `*lsp-bridge*' buf
     clojurec-mode-hook
     clojurescript-mode-hook
     clojurex-mode-hook
+    clojure-ts-mode-hook
+    clojurec-ts-mode-hook
+    clojurescript-ts-mode-hook
+    clojure-dart-ts-mode-hook
     sh-mode-hook
     bash-mode-hook
     web-mode-hook


### PR DESCRIPTION
This PR adds support for [`clojure-ts-mode`](https://github.com/clojure-emacs/clojure-ts-mode), the next generation of clojure modes.

I was not sure how to do the indentation since the line becomes very long, so I left it as simple as possible. Can change it to align by splitting the `ts`-modes to a new line if that is prefered.