### PR TITLE
fix: tempel backend error.

### DIFF
--- a/acm/acm-backend-tempel.el
+++ b/acm/acm-backend-tempel.el
@@ -30,8 +30,7 @@
                 :display-label snippet
                 :annotation "Tempel"
                 :backend "tempel"))
-        (cl-subseq match-snippets 0 (min (length match-snippets) acm-backend-tempel-candidates-number)))
-       candidates))))
+        (cl-subseq match-snippets 0 (min (length match-snippets) acm-backend-tempel-candidates-number)))))))
 
 (defun acm-backend-tempel-candidate-expand (candidate-info bound-start)
   (delete-region bound-start (point))
@@ -41,7 +40,7 @@
   (let ((snippet
          (alist-get (intern-soft (plist-get candidate :label))
                     (tempel--templates))))
-    (mapconcat #'tempel--print-element snippet " ")))
+    (mapconcat #'tempel--print-template snippet " ")))
 
 (provide 'acm-backend-tempel)
 


### PR DESCRIPTION
修复使用 tempel 作为后端的报错：

1. delete undefined and unused variable `candidates`
2. replace undefined function `tempel--print-element` with `tempel--print-template`