### PR TITLE
Lsp bridge peek file content scroll margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ lsp-bridge provides support for more than two language servers for many language
 - `lsp-bridge-symbols-enable-which-func`: Using lsp backend for `which-func`, disable by default
 - `lsp-bridge-enable-org-babel`: Use lsp completion in org babel, disable by default, if unable to complete, please make sure the string after begin_src exists in the `org-src-lang-modes` variable
 - `lsp-bridge-peek-file-content-height`: Display how many lines of file content in peek windows
+- `lsp-bridge-peek-file-content-scroll-margin`: Set how many lines of file content should be scroll up and down.
 - `lsp-bridge-peek-list-height`: Select the next option for definition and reference
 - `lsp-bridge-peek-ace-keys`: Keys to press when performing `lsp-bridge-peek-through`
 - `lsp-bridge-peek-ace-cancel-keys`: Keys to exit `lsp-bridge-peek-through`

--- a/lsp-bridge-peek.el
+++ b/lsp-bridge-peek.el
@@ -179,6 +179,12 @@ height and background properties of the face."
   :type 'integer
   :group 'lsp-bridge-peek)
 
+
+(defcustom lsp-bridge-peek-file-content-scroll-margin 1
+  "Set how much lsp-bridge-peek-file-content-next-line/-prev-line should scroll up and down."
+  :type 'integer
+  :group 'lsp-bridge-peek)
+
 (defcustom lsp-bridge-peek-list-height 3
   "Number of definitions/references displayed in the peek window."
   :type 'integer
@@ -659,12 +665,12 @@ When FORCE if non-nil, the content of the peek window is recalculated."
 (defun lsp-bridge-peek-file-content-next-line ()
   "Step through the next line of file content."
   (interactive)
-  (lsp-bridge-peek-file-content-move 1))
+  (lsp-bridge-peek-file-content-move lsp-bridge-peek-file-content-scroll-margin))
 
 (defun lsp-bridge-peek-file-content-prev-line ()
   "Step through the next line of file content."
   (interactive)
-  (lsp-bridge-peek-file-content-move -1))
+  (lsp-bridge-peek-file-content-move (* lsp-bridge-peek-file-content-scroll-margin -1)))
 
 (defun lsp-bridge-peek-jump ()
   "Jump to where the definition/reference is."


### PR DESCRIPTION
Wanted to have a possibility to set the amount of lines that the peek window is moved up and down. 