### PR TITLE
Add lsp-bridge-mode-lighter to customize lighter

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1899,11 +1899,16 @@ Default is `bottom-right', you can choose other value: `top-left', `top-right', 
 
 (defvar lsp-bridge-auto-format-code-timer nil)
 
+(defcustom lsp-bridge-mode-lighter " LSPB"
+  "Mode line lighter for LSP Bridge Mode."
+  :type 'string
+  :group 'lsp-bridge)
+
 ;;;###autoload
 (define-minor-mode lsp-bridge-mode
   "LSP Bridge mode."
   :keymap lsp-bridge-mode-map
-  :lighter " LSPB"
+  :lighter lsp-bridge-mode-lighter
   :init-value nil
   (if lsp-bridge-mode
       (lsp-bridge--enable)


### PR DESCRIPTION
I love the original modeline, so I'll make it customizable.

```el
;; init.el
(setopt lsp-bridge-mode-lighter " 橋")
```
<img width="1009" alt="スクリーンショット 2023-10-24 19 42 46" src="https://github.com/manateelazycat/lsp-bridge/assets/822086/96ef8345-392c-4fb9-9584-7e117b92d9d3">
