### PR TITLE
fix: choose lanugage id based on extension when using css lsp

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -391,6 +391,16 @@ class LspServer:
         return uri
 
     def send_did_open_notification(self, fa: "FileAction"):
+        # vscode-css-language-server uses languageId to initialize from different entry points
+        if self.server_info["name"] == "vscode-css-language-server":
+            _, extension = os.path.splitext(fa.filepath)
+            if extension == ".less":
+                self.server_info["languageId"] = "less"
+            elif extension == ".scss" or extension == ".sass":
+                self.server_info["languageId"] = "scss"
+            else:
+                self.server_info["languageId"] = "css"
+
         self.sender.send_notification("textDocument/didOpen", {
             "textDocument": {
                 "uri": self.parse_document_uri(fa.filepath, fa.external_file_link),

--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -26,6 +26,7 @@ import re
 import subprocess
 import threading
 import traceback
+import copy
 from subprocess import PIPE
 from sys import stderr
 from typing import TYPE_CHECKING, Dict
@@ -510,6 +511,7 @@ class LspServer:
             sessionSettings = settings.get(section, {})
 
             if self.server_info["name"] == "vscode-eslint-language-server":
+                sessionSettings = copy.copy(settings)
                 sessionSettings["workspaceFolder"] = {
                     "name": self.project_name,
                     "uri": path_to_uri(self.project_path),


### PR DESCRIPTION
@manateelazycat  if `lsp-bridge/langserver/vscode-css-language-server.json` was in Python, then the server specific code can live in each config file. But here is the most reasonable place to add the fix atm.