### PR TITLE
fix: fix eslint lsp config that workspace config requires full settings

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -509,6 +509,7 @@ class LspServer:
             sessionSettings = settings.get(section, {})
 
             if self.server_info["name"] == "vscode-eslint-language-server":
+                sessionSettings = settings
                 sessionSettings["workspaceFolder"] = {
                     "name": self.project_name,
                     "uri": path_to_uri(self.project_path),


### PR DESCRIPTION
eslint lsp now needs full session settings