### PR TITLE
fix lsp-bridge-inlay-hint-label-text

### DIFF
--- a/lsp-bridge-inlay-hint.el
+++ b/lsp-bridge-inlay-hint.el
@@ -114,15 +114,16 @@
        " "))
 
 (defun lsp-bridge-inlay-hint-label-text (label-info)
-  (defun lsp-bridge-inlay-hint-label-text (label-info)
-    (format "%s"
-            (if (listp label-info)
-                ;; We concat value of list if label is list.
-                (mapconcat (lambda (label)
-                             (plist-get label :value))
-                           label-info)
-              ;; Otherwise label is string, just return itself.
-              label-info))))
+  (format "%s"
+          (if (listp label-info)
+              ;; We concat value of list if label is list.
+              (mapconcat (lambda (label)
+                           (plist-get label :value))
+                         label-info
+                         "") ; Separator for mapconcat
+            ;; Otherwise label is string, just return itself.
+            label-info))
+  )
 
 (defun lsp-bridge-inlay-hint--render (filepath filehost inlay-hints)
   (lsp-bridge--with-file-buffer


### PR DESCRIPTION
我修改添加了一个函数：
```
(defun lsp-bridge-try-send-inlay-hint-request2 ()
  (interactive)
  (when lsp-bridge-enable-inlay-hint
    (lsp-bridge-inlay-hint)))
```

使用发现，报错信息

```
ERROR:epc:ReturnError([Symbol('wrong-type-argument'), Symbol('sequencep'), Symbol('lsp-bridge-inlay-hint-label-text')])
```

另外我发现使用kotlin-language-server时，使用`lsp-bridge-try-send-inlay-hint-request2`函数，我在*lsp-bridge*没发现发送inlayhint信息，而在rust中有明显的发送信息。能否帮忙看看kotlin-language-server?

我确定kotlin-language-server有inlayhint信息，我使用lsp-mode已经显示出来了。
