### PR TITLE
update kotlin config

### DIFF
--- a/langserver/kotlin-language-server.json
+++ b/langserver/kotlin-language-server.json
@@ -5,20 +5,39 @@
     "kotlin-language-server"
   ],
   "settings": {
-    "kotlin.externalSources": {
-      "autoConvertToKotlin": true,
-      "useKlsScheme": true
-    },
-    "kotlin.debugAdapter": {
-      "path": "",
-      "enabled": true
-    } ,
-    "kotlin.completion.snippets.enabled": true,
-    "kotlin.linting.debounceTime": 250,
-    "kotlin.compiler.jvm.target": "11",
-    "kotlin.trace.server": "off",
-    "kotlin.inlayHints.typeHints": true,
-    "kotlin.inlayHints.parameterHints": true,
-    "kotlin.inlayHints.chainedHints": true
+    "kotlin": {
+      "externalSources": {
+        "autoConvertToKotlin": true,
+        "useKlsScheme": true
+      },
+      "debugAdapter": {
+        "path": "",
+        "enabled": true
+      },
+      "completion": {
+        "snippets": {
+          "enabled": true
+        }
+      },
+      "linting": {
+        "debounceTime": 250
+      },
+      "compiler": {
+        "jvm": {
+          "target": "11"
+        }
+      },
+      "trace": {
+        "server": "off"
+      },
+      "languageServer": {
+        "path": "kotlin-language-server"
+      },
+      "inlayHints": {
+        "typeHints": true,
+        "parameterHints": true,
+        "chainedHints": true
+      }
+    }
   }
 }


### PR DESCRIPTION
kotlin-language-server的配置格式修改了，现在修正了，可以开启inlayhint提示。

macos 下必须使用源码编译的kotlin-language-server, 系统安装包可能会出错。其他系统没测试。