### PR TITLE
force send request inlayhint message as user defined

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -220,7 +220,8 @@ class LspServer:
         self.code_format_provider = False
         self.signature_help_provider = False
         self.workspace_symbol_provider = False
-        self.inlay_hint_provider = False
+        [enable_lsp_server_inlay_hint] = get_emacs_vars(["lsp-bridge-enable-inlay-hint"])
+        self.inlay_hint_provider = enable_lsp_server_inlay_hint
         self.semantic_tokens_provider = False
 
         self.code_action_kinds = [


### PR DESCRIPTION
我现在是手动开启发送inlayhint信息的，也就是  `self.inlay_hint_provider = True` , 不够智能。

lsp-bridge有个选项 `lsp-bridge-enable-inlay-hint` , 不管lsp-server返回inlayhint能力信息，根据 `lsp-bridge-enable-inlay-hint` 强制发送请求inlayhint信息。

这样的话，就可以做到了不需要手动修改底层代码，而且由用户配置发送请求inlayhint信息。