### PR TITLE
Apply face to an empty width match

### DIFF
--- a/lsp-bridge-ref.el
+++ b/lsp-bridge-ref.el
@@ -387,7 +387,7 @@ user more freedom to use rg with special arguments."
 
     ;; Highlight references.
     (goto-char (point-min))
-    (while (re-search-forward "\033\\[94m\\([^\033]+\\)\033\\[0m" nil t)
+    (while (re-search-forward "\033\\[94m\\([^\033]*\\)\033\\[0m" nil t)
       (replace-match (concat (propertize (match-string 1)
                                          'face nil 'font-lock-face 'lsp-bridge-ref-font-lock-match))
                      t t))


### PR DESCRIPTION
Due to a Language Server issue, ANSI escape codes are left unconverted to face when an empty interval is returned.

## Before

<img width="978" alt="スクリーンショット 2023-11-18 18 45 20" src="https://github.com/manateelazycat/lsp-bridge/assets/822086/2ecc366d-5119-4d05-911f-8da205ae8e13">

## After

<img width="991" alt="スクリーンショット 2023-11-18 18 45 44" src="https://github.com/manateelazycat/lsp-bridge/assets/822086/5d26e117-94da-4b84-bf17-665aa6efdf52">
