### PR TITLE
Enhance SSH Key Handling: support use of specified SSH private key

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -268,6 +268,13 @@ After set `lsp-bridge-completion-obey-trigger-characters-p' to nil, you need use
   :safe (lambda (v) (or (null v) (stringp v)))
   :group 'lsp-bridge)
 
+(defcustom lsp-bridge-user-ssh-private-key nil
+  "custom SSH private key path for use in SSH connections."
+  :type '(choice (const nil)
+                 (string))
+  :safe (lambda (v) (or (null v) (stringp v)))
+  :group 'lsp-bridge)
+
 (defcustom lsp-bridge-symbols-enable-which-func nil
   "Wether use lsp-bridge in which-func."
   :type 'boolean
@@ -510,7 +517,7 @@ Possible choices are pyright_ruff, pyright-background-analysis_ruff, jedi_ruff, 
     python-mode-hook
     ruby-mode-hook
     lua-mode-hook
- 	move-mode-hook
+    move-mode-hook
     rust-mode-hook
     rust-ts-mode-hook
     rustic-mode-hook


### PR DESCRIPTION
This change 
- rectify the misuse the name of `ssh_pub_key` 
-  add an option `lsp-bridge-user-ssh-private-key` for user to configurate the SSH private key they want to use.

# Rectify the misuse of the name `ssh_pub_key` 

Issue: The original code utilized a function named `ssh_pub_key` that misleadingly suggested it use a public SSH key to login SSH remote server. However, it is the **private SSH key** that are used for paramiko connection. This wrong naming could lead to confusion and potential misuse in the future.

You can look at the documentation https://docs.paramiko.org/en/latest/api/client.html#paramiko.client.SSHClient.connect
> key_filename ([str](https://docs.python.org/3.6/library/stdtypes.html#str)) – the filename, or list of filenames, of optional **private key(s)** and/or certs to try for authentication

> look_for_keys ([bool](https://docs.python.org/3.6/library/functions.html#bool)) – set to False to disable searching for discoverable private key files in ~/.ssh/

why it works even using the wrong file (SSH public key)? 

because `look_for_keys` is default to True, and paramiko will search for the default private key files in `~/.ssh`

Resolution: Renamed ssh_pub_key to ssh_private_key. This change aligns the function name with its actual purpose, improving code readability and maintainability.

# Introduction an new option lsp-bridge-user-ssh-private-key

Enhancement: Added the capability for users to explicitly specify the path to their SSH private key through a new configuration variable, `lsp-bridge-user-ssh-private-key`. 

Benefit: This change empowers users with custom SSH configurations or multiple SSH keys to precisely define which key should be used for SSH connections. It significantly increases the flexibility and adaptability of the LSP Bridge to various user environments. 

This option is **necessary** and useful when using dynamically generated SSH key pair to connect to a remote ssh server in a docker/container setting.

# conditional `look_for_keys` handling

When the lsp-bridge-user-ssh-private-key is set, look_for_keys is explicitly set to False to ensure that Paramiko uses the user-specified key instead of searching for keys in the default `~/.ssh` directory.

This adjustment ensures that the SSH connection uses the correct private key as defined by the user, thereby enhancing the security and reliability of the SSH connection.
