### PR TITLE
Make code action preview frame more visible

### DIFF
--- a/acm/acm-frame.el
+++ b/acm/acm-frame.el
@@ -300,8 +300,10 @@ influence of C1 on the result."
   (when (acm-frame-visible-p frame)
     (make-frame-invisible frame)))
 
-(defun acm-frame-adjust-frame-pos (frame &optional popup-pos margin)
-  "Adjust position to avoid out of screen."
+(defun acm-frame-adjust-frame-pos (frame &optional popup-pos margin action-menu-p)
+  "Adjust position to avoid out of screen.
+ACTION-MENU-P is used to give code action menu a special treat to make it more useful.
+Only when calling this function from code-action file should make this variable be true."
   (let* ((margin (or margin 50))
          (popup-pos (or popup-pos "point"))
          (main-window-x (car (frame-position acm-frame--emacs-frame)))
@@ -331,10 +333,11 @@ influence of C1 on the result."
                              (- (+ main-window-x main-window-width) frame-width margin)
                              frame-y))
        (when (> frame-bottom-edge main-window-bottom-limit)
-         (set-frame-position frame
-                             frame-x
-                             (- (+ main-window-y main-window-height) frame-height margin)
-                             ))))))
+         (if action-menu-p
+             (set-frame-position frame frame-x main-window-y)
+           (set-frame-position frame
+                               frame-x
+                               (- (+ main-window-y main-window-height) frame-height margin))))))))
 
 (defun acm-frame-can-display-p ()
   (not (or noninteractive

--- a/lsp-bridge-call-hierarchy.el
+++ b/lsp-bridge-call-hierarchy.el
@@ -126,6 +126,26 @@
   (interactive)
   (lsp-bridge-call-hierarchy--move -1))
 
+(defun lsp-bridge-call-hierarchy-preview-next ()
+  (interactive)
+  (with-selected-window (get-buffer-window "*lsp-bridge-code-action-preview*")
+    (scroll-up-line 5)))
+
+(defun lsp-bridge-call-hierarchy-preview-prev ()
+  (interactive)
+  (with-selected-window (get-buffer-window "*lsp-bridge-code-action-preview*")
+    (scroll-down-line 5)))
+
+(defun lsp-bridge-call-hierarchy-scroll-left ()
+  (interactive)
+  (with-selected-window (get-buffer-window "*lsp-bridge-code-action-preview*")
+    (scroll-left 5)))
+
+(defun lsp-bridge-call-hierarchy-scroll-right ()
+  (interactive)
+  (with-selected-window (get-buffer-window "*lsp-bridge-code-action-preview*")
+    (scroll-right 5)))
+
 (defun lsp-bridge-call-hierarchy-quit ()
   (interactive)
 
@@ -181,8 +201,10 @@
     (define-key map (kbd "C-p") 'lsp-bridge-call-hierarchy-prev)
     (define-key map (kbd "<down>") 'lsp-bridge-call-hierarchy-next)
     (define-key map (kbd "<up>") 'lsp-bridge-call-hierarchy-prev)
-    (define-key map (kbd "M-n") 'lsp-bridge-call-hierarchy-next)
-    (define-key map (kbd "M-p") 'lsp-bridge-call-hierarchy-prev)
+    (define-key map (kbd "M-n") 'lsp-bridge-call-hierarchy-preview-next)
+    (define-key map (kbd "M-p") 'lsp-bridge-call-hierarchy-preview-prev)
+    (define-key map (kbd "M-b") #'lsp-bridge-call-hierarchy-scroll-right)
+    (define-key map (kbd "M-f") #'lsp-bridge-call-hierarchy-scroll-left)
     (define-key map (kbd "m") 'lsp-bridge-call-hierarchy-select)
     (define-key map (kbd "RET") 'lsp-bridge-call-hierarchy-select)
     (define-key map (kbd "<escape>") 'lsp-bridge-call-hierarchy-quit)

--- a/lsp-bridge-code-action.el
+++ b/lsp-bridge-code-action.el
@@ -222,7 +222,7 @@ Please read https://microsoft.github.io/language-server-protocol/specifications/
     (acm-frame-set-frame-size lsp-bridge-call-hierarchy--frame
                               (max width call-frame-width)
                               (+ height menu-window-height))
-    (acm-frame-adjust-frame-pos lsp-bridge-call-hierarchy--frame)
+    (acm-frame-adjust-frame-pos lsp-bridge-call-hierarchy--frame nil nil t)
     (select-frame-set-input-focus lsp-bridge-call-hierarchy--frame)
 
     (let ((menu-window (get-buffer-window "*lsp-bridge-code-action-menu*"


### PR DESCRIPTION
调整了 `acm-frame-adjust-frame-pos` 对于 code action preview frame 的操作，以避免预览 buffer 的内容过多时导致 preview frame 超出显示范围。
同时，为 `lsp-bridge-call-hierarchy-mode` 添加了四个命令，使预览内容更加可视化。 