### PR TITLE
fix lsp-bridge-try-completion bug with lsp-bridge-enable-log set to t

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1221,7 +1221,7 @@ So we build this macro to restore postion after code format."
            (if (cl-every (lambda (pred)
                            (if (functionp pred)
                                (let ((result (funcall pred)))
-                                 (when (and lsp-bridge-enable-log (not eq result t))
+                                 (when (and lsp-bridge-enable-log (not (eq result t)))
                                    (message "*** lsp-bridge-try-completion execute predicate '%s' failed with result: '%s'" pred result))
                                  result)
                              t))


### PR DESCRIPTION
This bug causes `wrong-number-of-arguments` error when `lsp-bridge-enable-log` is set to `t` and will cause Emacs remove `lsp-bridge-monitor-post-command` from `post-command-hook`.