### PR TITLE
disable metadata and auto check after save

### DIFF
--- a/langserver/rust-analyzer.json
+++ b/langserver/rust-analyzer.json
@@ -9,15 +9,25 @@
       "enable": true
     },
     "cargo": {
-      "features": "all",
+      "features": "",
       "noDefaultFeatures": false,
       "runBuildScripts": true,
       "loadOutDirsFromCheck": true,
       "useRustcWrapperForBuildScripts": true,
-      "autoreload": true,
+      "autoreload": false,
       "buildScripts": {
-        "enable": true
-      }
+        "enable": true,
+        "rebuildOnSave": false,
+        "invocationLocation": "root",
+        "invocationStrategy": "once",
+        "overrideCommand": null
+        }
+      },
+    "checkOnSave": {
+      "enable": false,
+      "allTargets": false,
+      "features": "null",
+      "overrideCommand": null
     },
     "completion": {
       "addCallParenthesis": true,


### PR DESCRIPTION
根据 
https://github.com/rust-lang/rust-analyzer/blob/d410d4a2baf9e99b37b03dd42f06238b14374bf7/crates/rust-analyzer/src/config.rs#L79-L194
获取的配置信息

测试例子可以使用 https://github.com/bitcoindevkit/bdk/blob/master/crates/esplora/src/blocking_ext.rs

测试例子是个workspace, 修改代码后，只会导致第一次save之后使用cargo check。

但以前的配置是每次save都会使用cargo check, 这个会卡住不给编译。

我忘记用什么工具格式化配置了，手动格式化的，有可能要重新格式化一次。