### PR TITLE
enable all feature, only check current crate in workspace

### DIFF
--- a/langserver/rust-analyzer.json
+++ b/langserver/rust-analyzer.json
@@ -9,7 +9,7 @@
       "enable": true
     },
     "cargo": {
-      "features": "",
+      "features": "all",
       "noDefaultFeatures": false,
       "runBuildScripts": true,
       "loadOutDirsFromCheck": true,
@@ -25,9 +25,10 @@
       },
     "checkOnSave": {
       "enable": false,
-      "allTargets": false,
-      "features": "null",
-      "overrideCommand": null
+      "allTargets": true,
+      "features": "all",
+      "invocationLocation": "root",
+      "invocationStrategy": "once"
     },
     "completion": {
       "addCallParenthesis": true,


### PR DESCRIPTION
根据
https://github.com/rust-lang/rust-analyzer/blob/38f7a3498e0d5f0113294bbdc08f867cd527e65f/crates/rust-analyzer/src/config.rs#L127-L191
获取的配置信息

测试例子可以使用 https://github.com/bitcoindevkit/bdk

- [x] #836 引入了一个bug，如果crate有多个feature，不会编译。重新启用all-features。
- [x] 在workspace中可能会有多个crate，配置只检查当前crate，不检查其他的crate，会加快代码索引