### PR TITLE
Fix remote server connection

### DIFF
--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -134,15 +134,17 @@ class RemoteFileClient(threading.Thread):
         try:
             data = json.dumps(message)
             self.chan.sendall(f"{data}\n".encode("utf-8"))
-        except socket.error as e:       
+        except socket.error as e:
             raise SendMessageException() from e
 
     def run(self):
         chan_file = self.chan.makefile("r")
         while True:
-            message = chan_file.readline().strip()
-            if not message:
+            data = chan_file.readline().strip()
+            if not data:
                 break
+
+            message = parse_json_content(data)
             self.callback(message)
         self.chan.close()
 
@@ -188,63 +190,82 @@ class RemoteFileServer:
         self.event_loop = threading.Thread(target=self.event_dispatcher)
         self.event_loop.start()
 
-        # Build message loop.
-        self.message_queue = queue.Queue()
-        self.message_thread = threading.Thread(target=self.message_dispatcher)
-        self.message_thread.start()
-
-        self.file_dict = {}
+        self.client_socket = None
+        self.client_address = None
 
     def event_dispatcher(self):
         try:
             while True:
-                client_socket, client_address = self.server.accept()
+                self.client_socket, self.client_address = self.server.accept()
 
-                client_handler = threading.Thread(target=self.handle_client, args=(client_socket,))
-                client_handler.start()
-        except:
-            print(traceback.format_exc())
+                threading.Thread(target=self.handle_client).start()
+        except Exception as e:
+            logger.exception(e)
 
-    def message_dispatcher(self):
+    def handle_client(self):
         try:
+            client_file = self.client_socket.makefile('r')
             while True:
-                client_socket = self.message_queue.get(True)
-                self.handle_client(client_socket)
-                self.message_queue.task_done()
-        except:
-            print(traceback.format_exc())
+                data = client_file.readline().strip()
+                if not data:
+                    break
 
-    def handle_client(self, client_socket):
-        client_file = client_socket.makefile('r')
-        while True:
-            message = client_file.readline().strip()
-            if not message:
-                break
-            self.handle_message(message, client_socket)
-        client_socket.close()
+                message = parse_json_content(data)
+                resp = self.handle_message(message)
+                if resp:
+                    self.client_socket.send(f"{resp}\n".encode("utf-8"))
 
-    def handle_message(self, message, client_socket):
-        data = parse_json_content(message)
-        command = data["command"]
+            client_file.close()
+            self.client_socket.shutdown(socket.SHUT_RDWR)
+            self.client_socket.close()
+            log_time(f"Server port {self.port} socket close for client {self.client_address}")
+            self.client_socket = None
+            self.client_address = None
+        except Exception as e:
+            logger.exception(e)
+
+    def handle_message(self, message):
+        return
+
+    def send_message(self, message):
+        try:
+            if self.client_socket:
+                if self.client_address:
+                    message["host"] = self.client_address[0]
+
+                data = json.dumps(message)
+                self.client_socket.send(f"{data}\n".encode("utf-8"))
+        except Exception as e:
+            logger.exception(e)
+            raise SendMessageException() from e
+
+
+class FileSyncServer(RemoteFileServer):
+    def __init__(self, host, port):
+        self.file_dict = {}
+        super().__init__(host, port)
+
+    def handle_message(self, message):
+        command = message["command"]
 
         if command == "open_file":
-            self.handle_open_file(data, client_socket)
+            return self.handle_open_file(message)
         elif command == "save_file":
-            self.handle_save_file(data, client_socket)
+            return self.handle_save_file(message)
         elif command == "close_file":
-            self.handle_close_file(data, client_socket)
+            return self.handle_close_file(message)
         elif command == "change_file":
-            self.handle_change_file(data, client_socket)
+            return self.handle_change_file(message)
         elif command == "tramp_sync":
-            self.handle_tramp_sync(data, client_socket)
+            return self.handle_tramp_sync(message)
 
-    def handle_tramp_sync(self, data, client_socket):
-        tramp_connection_info = data["tramp_connection_info"]
+    def handle_tramp_sync(self, message):
+        tramp_connection_info = message["tramp_connection_info"]
         set_remote_tramp_connection_info(tramp_connection_info)
 
-    def handle_open_file(self, data, client_socket):
-        path = os.path.expanduser(data["path"])
-        response = {**data, "path": path}
+    def handle_open_file(self, message):
+        path = os.path.expanduser(message["path"])
+        response = {**message, "path": path}
 
         if os.path.exists(path):
             with open(path) as f:
@@ -256,34 +277,91 @@ class RemoteFileServer:
                 self.file_dict[path] = content
         else:
             response.update({
-                "path": path,              
+                "path": path,
                 "content": "",
                 "error": f"Cannot found file {path} on server.",
-            })          
+            })
 
-        response_data = json.dumps(response)
-        client_socket.send(f"{response_data}\n".encode("utf-8"))
+        return json.dumps(response)
 
-    def handle_change_file(self, data, client_socket):
-        path = data["path"]
+    def handle_change_file(self, message):
+        path = message["path"]
         if path not in self.file_dict:
             with open(path) as f:
                 self.file_dict[path] = f.read()
 
-        self.file_dict[path] = rebuild_content_from_diff(self.file_dict[path], data["args"][0], data["args"][1], data["args"][3])
+        self.file_dict[path] = rebuild_content_from_diff(self.file_dict[path], message["args"][0], message["args"][1], message["args"][3])
 
-    def handle_save_file(self, data, client_socket):
-        path = data["path"]
+    def handle_save_file(self, message):
+        path = message["path"]
 
         if path in self.file_dict:
             with open(path, 'w') as file:
                 file.write(self.file_dict[path])
 
-    def handle_close_file(self, data, client_socket):
-        path = data["path"]
+    def handle_close_file(self, message):
+        path = message["path"]
 
         if path in self.file_dict:
             del self.file_dict[path]
+
+
+class FileElispServer(RemoteFileServer):
+    def __init__(self, host, port, lsp_bridge):
+        self.lsp_bridge = lsp_bridge
+        self.result_queue = queue.Queue()
+        super().__init__(host, port)
+
+    def handle_client(self):
+        threading.Thread(target=super().handle_client).start()
+        # remote server lsp-bridge process use this cient_socket to call elisp function from local Emacs.
+        log_time(f"Client connect from {self.client_address[0]}:{self.client_address[1]}")
+        self.lsp_bridge.init_search_backends()
+        log_time("init_search_backends finish")
+        # Signal that init_search_backends is done
+        self.lsp_bridge.init_search_backends_complete_event.set()
+
+    def handle_message(self, message):
+        if message == "Connect":
+            # Drop "say hello" message from local Emacs.
+            return
+        else:
+            self.result_queue.put(message)
+
+    def call_remote_rpc(self, message):
+        try:
+            self.send_message(message)
+        except Exception as e:
+            logger.exception(e)
+            return None
+        else:
+            result = self.result_queue.get()
+            self.result_queue.task_done()
+            return result
+
+
+class FileCommandServer(RemoteFileServer):
+    def __init__(self, host, port, lsp_bridge):
+        self.lsp_bridge = lsp_bridge
+        super().__init__(host, port)
+
+    def handle_client(self):
+        # we wait for init_search_backends to finish execution
+        # before start thread to handle remote request
+        log_time("wait for init_search_backends to finsih execution")
+        self.lsp_bridge.init_search_backends_complete_event.wait()
+        super().handle_client()
+
+    def handle_message(self, message):
+        if message["command"] == "lsp_request":
+            # Call LSP request.
+            self.lsp_bridge.event_queue.put({
+                "name": "action_func",
+                "content": ("_{}".format(message["method"]), [message["path"]] + message["args"])
+            })
+        elif message["command"] == "func_request":
+            # Call lsp-bridge normal function.
+            getattr(self.lsp_bridge, message["method"])(*message["args"])
 
 
 def save_ip_to_file(ip, filename):

--- a/core/utils.py
+++ b/core/utils.py
@@ -367,6 +367,10 @@ def log_time(message):
     import datetime
     logger.info("\n--- [{}] {}".format(datetime.datetime.now().time(), message))
 
+def log_time_debug(message):
+    import datetime
+    logger.debug("\n--- [{}] {}".format(datetime.datetime.now().time(), message))
+
 def get_os_name():
     return platform.system().lower()
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -110,34 +110,33 @@ def merge_emacs_exec_path():
 
         is_merge_emacs_exec_path = True
 
-lsp_file_host = ""
-def set_lsp_file_host(host):
-    global lsp_file_host
-    lsp_file_host = host
-
+lsp_bridge = None
 def get_lsp_file_host():
-    global lsp_file_host
-    return lsp_file_host
+    global lsp_bridge
 
-remote_file_server = None
-def set_remote_file_server(server):
-    global remote_file_server
+    if lsp_bridge and lsp_bridge.file_command_server:
+        return lsp_bridge.file_command_server.client_address[0]
+    else:
+        return None
 
-    remote_file_server = server
+def set_lsp_bridge_server(bridge):
+    global lsp_bridge
+
+    lsp_bridge = bridge
 
 def get_buffer_content(filename, buffer_name):
-    global remote_file_server, lsp_file_host
+    global lsp_bridge
 
-    if lsp_file_host != "":
-        return remote_file_server.file_dict[filename]
+    if lsp_bridge and lsp_bridge.file_server:
+        return lsp_bridge.file_server.file_dict[filename]
     else:
         return get_emacs_func_result('get-buffer-content', buffer_name)
 
 def get_file_content_from_file_server(filename):
-    global remote_file_server
+    global lsp_bridge
 
-    if filename in remote_file_server.file_dict:
-        return remote_file_server.file_dict[filename]
+    if lsp_bridge and lsp_bridge.file_server and filename in lsp_bridge.file_server.file_dict:
+        return lsp_bridge.file_server.file_dict[filename]
     else:
         return ""
 
@@ -156,44 +155,8 @@ def get_remote_tramp_connection_info():
     global remote_tramp_connection_info
     return remote_tramp_connection_info
 
-remote_eval_socket = None
-def set_remote_eval_socket(socket):
-    global remote_eval_socket
-
-    remote_eval_socket = socket
-
-remote_rpc_socket = None
-remote_rpc_host = None
-def set_remote_rpc_socket(socket, host):
-    global remote_rpc_socket
-    global remote_rpc_host
-
-    remote_rpc_socket = socket
-    remote_rpc_host = host
-
-def get_remote_rpc_socket():
-    global remote_rpc_socket
-    global remote_rpc_host
-    return remote_rpc_socket, remote_rpc_host
-
-def call_remote_rpc(message):
-    remote_rpc_socket, remote_rpc_host = get_remote_rpc_socket()
-
-    if remote_rpc_socket is not None:
-        message["host"] = remote_rpc_host
-        data = json.dumps(message)
-        remote_rpc_socket.send(f"{data}\n".encode("utf-8"))
-
-        socket_file = remote_rpc_socket.makefile("r")
-        result = socket_file.readline().strip()
-        socket_file.close()
-
-        return result
-    else:
-        return None
-
 def eval_in_emacs(method_name, *args):
-    global remote_eval_socket
+    global lsp_bridge
 
     if test_interceptor:  # for test purpose, record all eval_in_emacs calls
         test_interceptor(method_name, args)
@@ -204,13 +167,11 @@ def eval_in_emacs(method_name, *args):
     logger.debug("Eval in Emacs: %s", sexp)
 
     # Call eval-in-emacs elisp function.
-    if remote_eval_socket:
-        message = {
+    if lsp_bridge and lsp_bridge.file_command_server:
+        lsp_bridge.file_command_server.send_message({
             "command": "eval-in-emacs",
             "sexp": [sexp]
-        }
-        data = json.dumps(message)
-        remote_eval_socket.send(f"{data}\n".encode("utf-8"))
+        })
     else:
         epc_client.call("eval-in-emacs", [sexp])    # type: ignore
 
@@ -260,29 +221,27 @@ def convert_emacs_bool(symbol_value, symbol_is_boolean):
 
 
 def get_emacs_vars(args):
-    global remote_rpc_socket
+    global lsp_bridge
 
-    if remote_rpc_socket:
-        results = call_remote_rpc({
+    if lsp_bridge and lsp_bridge.file_elisp_server:
+        return lsp_bridge.file_elisp_server.call_remote_rpc({
             "command": "get_emacs_vars",
             "args": args
         })
-        return parse_json_content(results)
     else:
         results = epc_client.call_sync("get-emacs-vars", args)
         return list(map(lambda result: convert_emacs_bool(result[0], result[1]) if result != [] else False, results))
 
 def get_emacs_func_result(method_name, *args):
     """Call eval-in-emacs elisp function synchronously and return the result."""
-    global remote_rpc_socket
+    global lsp_bridge
 
-    if remote_rpc_socket:
-        result = call_remote_rpc({
+    if lsp_bridge and lsp_bridge.file_elisp_server:
+        return lsp_bridge.file_elisp_server.call_remote_rpc({
             "command": "get_emacs_func_result",
             "method": method_name,
             "args": args
         })
-        return parse_json_content(result)
     else:
         result = epc_client.call_sync(method_name, args)    # type: ignore
         return result

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -972,8 +972,11 @@ So we build this macro to restore postion after code format."
        (lsp-bridge-process-live-p)))
 
 (defun lsp-bridge-call-file-api (method &rest args)
-  (if (lsp-bridge-is-remote-file)
-      (lsp-bridge-remote-send-lsp-request method args)
+  (if (file-remote-p (buffer-file-name))
+      (if (lsp-bridge-is-remote-file)
+          (lsp-bridge-remote-send-lsp-request method args)
+        (message "[LSP-Bridge] remote file \"%s\" is updating info... skip call %s."
+                 (buffer-file-name) method))
     (when (lsp-bridge-call-file-api-p)
       (if (and (boundp 'acm-backend-lsp-filepath)
                (file-exists-p acm-backend-lsp-filepath))
@@ -2612,7 +2615,9 @@ the context of that buffer. If the buffer is created by
     (read-only-mode -1)
 
     (add-hook 'kill-buffer-hook 'lsp-bridge-remote-kill-buffer nil t)
-    (setq lsp-bridge-tramp-sync-var t)))
+    (setq lsp-bridge-tramp-sync-var t)
+    (message "[LSP-Bridge] remote file %s updated info successfully."
+             (buffer-file-name))))
 
 (defun lsp-bridge-tramp-show-hostnames ()
   (interactive)

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -151,6 +151,13 @@ Setting this to nil or 0 will turn off the indicator."
   :type 'number
   :group 'lsp-bridge)
 
+(defcustom lsp-bridge-remote-heartbeat-interval nil
+  "Interval for sending heartbeat to server in seconds.
+
+Setting this to nil or 0 will turn off the heartbeat mechanism."
+  :type 'number
+  :group 'lsp-bridge)
+
 (defcustom lsp-bridge-enable-mode-line t
   "Whether display LSP-bridge's server info in mode-line ."
   :type 'boolean

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -2640,7 +2640,7 @@ I haven't idea how to make lsp-bridge works with `electric-indent-mode', PR are 
 
 (defun lsp-bridge-sync-tramp-remote ()
   (interactive)
-  (let* ((file-name (buffer-file-name))
+  (let* ((file-name (lsp-bridge-get-buffer-file-name-text))
          (tramp-vec (tramp-dissect-file-name file-name))
          (user (tramp-file-name-user tramp-vec))
          (host (tramp-file-name-host tramp-vec))

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1654,6 +1654,7 @@ So we build this macro to restore postion after code format."
         (lsp-bridge-remote-send-func-request "search_file_words_index_files" (list files)))
     (let ((files (cl-remove-if (lambda (elt)
                                  (or (null elt)
+                                     (file-remote-p elt)
                                      (member (file-name-extension elt)
                                              lsp-bridge-search-words-prohibit-file-extensions)))
                                (mapcar (lambda (b) (lsp-bridge-buffer-file-name (buffer-file-name b))) (buffer-list)))))


### PR DESCRIPTION
Add a `heartbeat` mechanism ffd0b982be317ac2c16b1ac22808c092414fe4ee for keeping remote connection alive to resovle #831 .
In the process of analyzing #831 ,I found some other bugs to fix here:

1. 431171c7bf192e7b809a4d970b65cde2d68d8609 `lsp-bridge-is-remote-file` needs synchronization with the server, so it is not real-time. We should not send requests for these remote files in updating to local servers or we will get unexpected errors. Before remote sync done, we just skip requests for these files.
2. c328cc8fc4627d72672c02ba4b88e713000009b1 We should call `sync_tramp_remote` with pure text buffer name.
3. ceb2f189a461c8c2efa0a2c43240d83d2f4ad408 When we have both opened remote files and local files and do `lsp-bridge-restart-process` in a local file buffer, we would get errors if we do not remove remote files on indexing.

Besides, the code for LspBridge remote server seems to be in a mess and hard to understand. So I tried to do a refactor. 
6ce0a1a773826af8fa7bcaa297799fed6a653be3 99476ec9a0d328132f831c244dbdc8728c912f68 b1200f0882d55822d044071c98dae6c33984cf94