### PR TITLE
Fix jdtls, rust-analyzer documentation issues.

### DIFF
--- a/core/handler/hover.py
+++ b/core/handler/hover.py
@@ -35,9 +35,17 @@ class Hover(Handler):
             elif "language" in contents:
                 render_strings.append(make_code_block(contents["language"], contents["value"]))
         elif content_type == list:
+            language = ""
             for item in contents:
-                if item != "":
+                if type(item) == dict:
+                    language = item["language"]
                     self.parse_hover_contents(item, render_strings)
+                if type(item) == str:
+                    if item != "":
+                        if language == "java":
+                            render_strings.append(item)
+                        else:
+                            self.parse_hover_contents(item, render_strings)
         return "\n".join(render_strings)
 
     def process_response(self, response: dict) -> None:

--- a/langserver/jdtls.json
+++ b/langserver/jdtls.json
@@ -5,6 +5,13 @@
     "jdtls"
   ],
   "settings": {},
+  "capabilities": {
+    "textDocument": {
+      "hover": {
+        "contentFormat": ["markdown"]
+      }
+    }
+  },
   "initializationOptions": {
     "settings": {
       "java": {

--- a/langserver/rust-analyzer.json
+++ b/langserver/rust-analyzer.json
@@ -3,6 +3,13 @@
   "languageId": "rust",
   "command": ["rust-analyzer"],
   "settings": {},
+  "capabilities": {
+    "textDocument": {
+      "hover": {
+        "contentFormat": ["markdown"]
+      }
+    }
+  },
   "initializationOptions": {
     "enableExperimental": false,
     "diagnostics": {


### PR DESCRIPTION
current jdtls lsp server textDocument/hover response contains a dict and then a plaintext, such as
```json
{
   "contents": [
     {
        "language": "java",
        "value": "org.springframework.boot.SpringBootApplication"
     },
     "Class that can be used to bootstrap ....."
   ]
}
```
Lsp-bridge renders a ```text``` block with plaintext.

This patch checks response for "language": "java", and render doc contents without modification when java found, since responding doc already in "markdown" format.

Configure "jdtls" and "rust-analyzer"  to request "markdown" format content in textDocument/hover requests.