### PR TITLE
Skip calling file api when we are updating tramp file info

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -974,8 +974,11 @@ So we build this macro to restore postion after code format."
        (lsp-bridge-process-live-p)))
 
 (defun lsp-bridge-call-file-api (method &rest args)
-  (if (lsp-bridge-is-remote-file)
-      (lsp-bridge-remote-send-lsp-request method args)
+  (if (file-remote-p (buffer-file-name))
+      (if (lsp-bridge-is-remote-file)
+          (lsp-bridge-remote-send-lsp-request method args)
+        (message "[LSP-Bridge] remote file \"%s\" is updating info... skip call %s."
+                 (buffer-file-name) method))
     (when (lsp-bridge-call-file-api-p)
       (if (and (boundp 'acm-backend-lsp-filepath)
                (file-exists-p acm-backend-lsp-filepath))
@@ -2614,7 +2617,9 @@ the context of that buffer. If the buffer is created by
     (read-only-mode -1)
 
     (add-hook 'kill-buffer-hook 'lsp-bridge-remote-kill-buffer nil t)
-    (setq lsp-bridge-tramp-sync-var t)))
+    (setq lsp-bridge-tramp-sync-var t)
+    (message "[LSP-Bridge] remote file %s updated info successfully."
+             (buffer-file-name))))
 
 (defun lsp-bridge-tramp-show-hostnames ()
   (interactive)


### PR DESCRIPTION
When a tramp file is opened, its information is updated by calling `lsp-bridge-sync-tramp-remote` and will be finished in `lsp-bridge-update-tramp-file-info`. Before it is done, `lsp-bridge-remote-file-flag` is nil and related remote file info variables are not set. If we call file api this time, it will send the request to local lsp server(local epc call). Because the file is a remote file in fact, we won't get right result frome local server and it might leads to some unpredicatable exception. So we add check in `lsp-bridge-call-file-api` to skip the call if update is not finished.