### PR TITLE
Remove remote files on indexing local files

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1653,6 +1653,7 @@ So we build this macro to restore postion after code format."
         (lsp-bridge-remote-send-func-request "search_file_words_index_files" (list files)))
     (let ((files (cl-remove-if (lambda (elt)
                                  (or (null elt)
+                                     (file-remote-p elt)
                                      (member (file-name-extension elt)
                                              lsp-bridge-search-words-prohibit-file-extensions)))
                                (mapcar (lambda (b) (lsp-bridge-buffer-file-name (buffer-file-name b))) (buffer-list)))))


### PR DESCRIPTION
In the branch for indexing local files, it didn't remove local files from `buffer-list`. Calling `search_file_words_index_files` for local with remote file names will bring error. So we need to add a check rule `(file-remote-p elt)`.