### PR TITLE
Unify receive_remote_message for different file servers

### DIFF
--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -140,9 +140,11 @@ class RemoteFileClient(threading.Thread):
     def run(self):
         chan_file = self.chan.makefile("r")
         while True:
-            message = chan_file.readline().strip()
-            if not message:
+            data = chan_file.readline().strip()
+            if not data:
                 break
+
+            message = parse_json_content(data)
             self.callback(message)
         self.chan.close()
 


### PR DESCRIPTION
Add a queue for elisp channel to unify remote message process and parse json in common code instead of each handler.