### PR TITLE
Unify send_remote_message to different file servers

### DIFF
--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -316,11 +316,6 @@ class FileElispServer(RemoteFileServer):
         # remote server lsp-bridge process use this cient_socket to call elisp function from local Emacs.
         log_time(f"Client connect from {self.client_address[0]}:{self.client_address[1]}")
 
-        # Drop first "say hello" message from local Emacs.
-        socket_file = self.client_socket.makefile("r")
-        socket_file.readline().strip()
-        socket_file.close()
-
         threading.Thread(target=super().handle_client).start()
 
         self.lsp_bridge.init_search_backends()
@@ -329,7 +324,11 @@ class FileElispServer(RemoteFileServer):
         self.lsp_bridge.init_search_backends_complete_event.set()
 
     def handle_message(self, message):
-        self.result_queue.put(message)
+        if message == "Connect":
+            # Drop "say hello" message from local Emacs.
+            return
+        else:
+            self.result_queue.put(message)
 
     def call_remote_rpc(self, message):
         try:

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -171,6 +171,12 @@ class LspBridge:
                                                           args=(self.remote_file_sender_queue, REMOTE_FILE_SYNC_CHANNEL))
         self.remote_file_sender_thread.start()
 
+        # Build loop to reply remote rpc command.
+        self.remote_file_elisp_sender_queue = queue.Queue()
+        self.remote_file_elisp_sender_thread = threading.Thread(target=self.send_message_dispatcher,
+                                                          args=(self.remote_file_elisp_sender_queue, REMOTE_FILE_ELISP_CHANNEL))
+        self.remote_file_elisp_sender_thread.start()
+
         # Build loop to call remote Python command.
         self.remote_file_command_sender_queue = queue.Queue()
         self.remote_file_command_sender_thread = threading.Thread(target=self.send_message_dispatcher,
@@ -265,17 +271,10 @@ class LspBridge:
 
         return client
 
-    def send_remote_file_message(self, host, message):
-        self.remote_file_sender_queue.put({
-            "host": host,
-            "message": message
-        })
-
-    def send_lsp_bridge_message(self, host, message):
-        self.remote_file_command_sender_queue.put({
-            "host": host,
-            "message": message
-        })
+    def send_remote_message(self, host, queue, message, wait=False):
+        queue.put({"host": host, "message": message})
+        if wait:
+            queue.join()
 
     def send_message_dispatcher(self, queue, port):
         try:
@@ -383,16 +382,15 @@ class LspBridge:
 
         client_id = f"{server_host}:{REMOTE_FILE_ELISP_CHANNEL}"
         if client_id not in self.client_dict:
-            client = self.get_socket_client(server_host, REMOTE_FILE_ELISP_CHANNEL)
-            if client:
-                # send "say hello" upon establishing the first connection
-                client.send_message("Connect")
+            # send "say hello" upon establishing the first connection
+            self.send_remote_message(server_host, self.remote_file_elisp_sender_queue, "Connect", True)
 
-            self.send_remote_file_message(server_host, {
-                "command": "tramp_sync",
-                "server": server_host,
-                "tramp_connection_info": tramp_connection_info,
-            })
+            self.send_remote_message(
+                server_host, self.remote_file_sender_queue, {
+                    "command": "tramp_sync",
+                    "server": server_host,
+                    "tramp_connection_info": tramp_connection_info,
+                })
 
         eval_in_emacs("lsp-bridge-update-tramp-file-info", tramp_file_name, tramp_connection_info, server_host, path)
         self.sync_tramp_remote_complete_event.set()
@@ -429,11 +427,8 @@ class LspBridge:
 
                 client_id = f"{server_host}:{REMOTE_FILE_ELISP_CHANNEL}"
                 if client_id not in self.client_dict:
-                    client = self.get_socket_client(server_host, REMOTE_FILE_ELISP_CHANNEL)
                     # send "say hello" upon establishing the first connection
-                    if client:
-                        client.send_message("Connect")
-
+                    self.send_remote_message(server_host, self.remote_file_elisp_sender_queue, "Connect", True)
                 message_emacs(f"Open {server_username}@{server_host}#{ssh_port}:{server_path}...")
                 # Add TRAMP-related fields
                 # The following fields: tramp_method, user, server, port, and path
@@ -441,7 +436,8 @@ class LspBridge:
                 # These variables facilitate the construction of a TRAMP file name,
                 # and then allow the buffer to reconnect to a restarted remote lsp-bridge process
                 # using the same logic with reconnecting a TRAMP remote file buffer.
-                self.send_remote_file_message(server_host, {
+                self.send_remote_message(
+                    server_host, self.remote_file_sender_queue, {
                     "command": "open_file",
                     "tramp_method": "ssh",
                     "user": server_username,
@@ -456,7 +452,8 @@ class LspBridge:
 
     @threaded
     def save_remote_file(self, remote_file_host, remote_file_path):
-        self.send_remote_file_message(remote_file_host, {
+        self.send_remote_message(
+            remote_file_host, self.remote_file_sender_queue, {
             "command": "save_file",
             "server": remote_file_host,
             "path": remote_file_path
@@ -464,7 +461,8 @@ class LspBridge:
 
     @threaded
     def close_remote_file(self, remote_file_host, remote_file_path):
-        self.send_remote_file_message(remote_file_host, {
+        self.send_remote_message(
+            remote_file_host, self.remote_file_sender_queue, {
             "command": "close_file",
             "server": remote_file_host,
             "path": remote_file_path
@@ -474,14 +472,16 @@ class LspBridge:
     @threaded
     def lsp_request(self, remote_file_host, remote_file_path, method, args):
         if method == "change_file":
-            self.send_remote_file_message(remote_file_host, {
+            self.send_remote_message(
+                remote_file_host, self.remote_file_sender_queue, {
                 "command": "change_file",
                 "server": remote_file_host,
                 "path": remote_file_path,
                 "args": list(map(epc_arg_transformer, args))
             })
 
-        self.send_lsp_bridge_message(remote_file_host, {
+        self.send_remote_message(
+            remote_file_host, self.remote_file_command_sender_queue, {
             "command": "lsp_request",
             "server": remote_file_host,
             "path": remote_file_path,
@@ -491,7 +491,8 @@ class LspBridge:
 
     @threaded
     def func_request(self, remote_file_host, remote_file_path, method, args):
-        self.send_lsp_bridge_message(remote_file_host, {
+        self.send_remote_message(
+            remote_file_host, self.remote_file_command_sender_queue, {
             "command": "func_request",
             "server": remote_file_host,
             "path": remote_file_path,
@@ -541,9 +542,7 @@ class LspBridge:
             logger.error("Unsupported command %s", message["command"])
             result = None
 
-        client = self.get_socket_client(host, REMOTE_FILE_ELISP_CHANNEL)
-        if client:
-            client.send_message(result)
+        self.send_remote_message(host, self.remote_file_elisp_sender_queue, result)
 
     # Functions for local handling
     def event_dispatcher(self):


### PR DESCRIPTION
Use same function with different sender queue for different file servers and simplify sending 'Connect' message.