### PR TITLE
Add heartbeat mechanism for remote usage

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -151,6 +151,13 @@ Setting this to nil or 0 will turn off the indicator."
   :type 'number
   :group 'lsp-bridge)
 
+(defcustom lsp-bridge-remote-heartbeat-interval nil
+  "Interval for sending heartbeat to server in seconds.
+
+Setting this to nil or 0 will turn off the heartbeat mechanism."
+  :type 'number
+  :group 'lsp-bridge)
+
 (defcustom lsp-bridge-enable-mode-line t
   "Whether display LSP-bridge's server info in mode-line ."
   :type 'boolean


### PR DESCRIPTION
If client does not send messages to the server for more than a specified time(e.g. 2h12min for me), the server will close the socket while the client can still send messages without error. However, the server will not receive and handle any more messages.
In order to solve this issue, we add a mechanism to send heartbeats to the server to keep the connection alive.