### PR TITLE
Support heartbeat for remote connections

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -365,6 +365,10 @@ def log_time(message):
     import datetime
     logger.info("\n--- [{}] {}".format(datetime.datetime.now().time(), message))
 
+def log_time_debug(message):
+    import datetime
+    logger.debug("\n--- [{}] {}".format(datetime.datetime.now().time(), message))
+
 def get_os_name():
     return platform.system().lower()
 

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -151,6 +151,13 @@ Setting this to nil or 0 will turn off the indicator."
   :type 'number
   :group 'lsp-bridge)
 
+(defcustom lsp-bridge-remote-heartbeat-interval nil
+  "Interval for sending heartbeat to server in seconds.
+
+Setting this to nil or 0 will turn off the heartbeat mechanism."
+  :type 'number
+  :group 'lsp-bridge)
+
 (defcustom lsp-bridge-enable-mode-line t
   "Whether display LSP-bridge's server info in mode-line ."
   :type 'boolean


### PR DESCRIPTION
If client does not send messages to the server for more than a specific time(e.g. 2h12min for me), the server will close the socket while the client can still send messages without error. However, the server will not receive and handle any more messages. In order to solve this issue, we add a mechanism to send heartbeats to the server to keep the connection alive.