### PR TITLE
Support jumping to references for remote files without tramp

### DIFF
--- a/core/handler/find_references.py
+++ b/core/handler/find_references.py
@@ -34,9 +34,9 @@ class FindReferences(Handler):
 
             references_counter = 0
             references_content = ""
-            tramp_connection_info = get_remote_tramp_connection_info()
+            remote_connection_info = get_remote_connection_info()
             for i, (path, ranges) in enumerate(references_dict.items()):
-                references_content += "".join(["\n", REFERENCE_PATH, tramp_connection_info, path, REFERENCE_ENDC, "\n"])
+                references_content += "".join(["\n", REFERENCE_PATH, remote_connection_info, path, REFERENCE_ENDC, "\n"])
 
                 for rg in ranges:
                     line = rg["start"]["line"]
@@ -54,4 +54,3 @@ class FindReferences(Handler):
             linecache.clearcache()  # clear line cache
 
             eval_in_emacs("lsp-bridge-references--popup", references_content, references_counter, self.pos)
-

--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -259,12 +259,12 @@ class FileSyncServer(RemoteFileServer):
             return self.handle_close_file(message)
         elif command == "change_file":
             return self.handle_change_file(message)
-        elif command == "tramp_sync":
-            return self.handle_tramp_sync(message)
+        elif command == "remote_sync":
+            return self.handle_remote_sync(message)
 
-    def handle_tramp_sync(self, message):
-        tramp_connection_info = message["tramp_connection_info"]
-        set_remote_tramp_connection_info(tramp_connection_info)
+    def handle_remote_sync(self, message):
+        remote_info = message["remote_connection_info"]
+        set_remote_connection_info(remote_info)
 
     def handle_open_file(self, message):
         path = os.path.expanduser(message["path"])

--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -35,19 +35,22 @@ class SendMessageException(Exception):
 class RemoteFileClient(threading.Thread):
     remote_password_dict = {}
 
-    def __init__(self, ssh_host, ssh_user, ssh_port, server_port, callback, use_gssapi=False, proxy_command=None):
+    def __init__(self, ssh_conf, server_port, callback):
         threading.Thread.__init__(self)
 
         # Init.
-        self.ssh_host = ssh_host
-        self.ssh_user = ssh_user
-        self.ssh_port = ssh_port
+        self.ssh_host = ssh_conf['hostname']
+        self.ssh_user = ssh_conf.get('user', "root")
+        self.ssh_port = ssh_conf.get('port', 22)
         self.server_port = server_port
         self.callback = callback
 
         [self.user_ssh_private_key] = get_emacs_vars(["lsp-bridge-user-ssh-private-key"])
 
-        self.ssh = self.connect_ssh(use_gssapi, proxy_command)
+        self.ssh = self.connect_ssh(
+            ssh_conf.get('gssapiauthentication', 'no') in ('yes'),
+            ssh_conf.get('proxycommand', None)
+        )
         # after successful login, don't create a channel yet
         # caller can use client ssh to execute command on remote server
         # ande then call create_channel() to create the channel

--- a/core/utils.py
+++ b/core/utils.py
@@ -398,15 +398,16 @@ def is_valid_ip_path(ssh_path):
 
 def split_ssh_path(ssh_path):
     """Split SSH-PATH into username, host, port and path."""
-    pattern = r"^(?:([a-z_][a-z0-9_\.-]*)@)?((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?::(\d+))?:?(.*)$"
+    pattern = r"^((?:([a-z_][a-z0-9_\.-]*)@)?((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?::(\d+))?):?(.*)$"
     match = re.match(pattern, ssh_path)
     if match:
-        username, host, port, path = match.groups()
-        if not username:
-            username = None
-        if not port:
-            port = None
-        return (username, host, port, path)
+        remote_info, username, host, port, path = match.groups()
+        ssh_conf = {'hostname' : host}
+        if username:
+            ssh_conf['user'] = username
+        if port:
+            ssh_conf['port'] = port
+        return (remote_info, host, ssh_conf, path)
     else:
         return None
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -144,14 +144,14 @@ def get_current_line():
 def get_ssh_password(user, host, port):
     return get_emacs_func_result('get-ssh-password', user, host, port)
 
-remote_tramp_connection_info = ""
-def set_remote_tramp_connection_info(tramp_connection_info):
-    global remote_tramp_connection_info
-    remote_tramp_connection_info = tramp_connection_info
+remote_connection_info = ""
+def set_remote_connection_info(remote_info):
+    global remote_connection_info
+    remote_connection_info = remote_info
 
-def get_remote_tramp_connection_info():
-    global remote_tramp_connection_info
-    return remote_tramp_connection_info
+def get_remote_connection_info():
+    global remote_connection_info
+    return remote_connection_info
 
 def eval_in_emacs(method_name, *args):
     global lsp_bridge_server
@@ -392,13 +392,13 @@ def is_valid_ip(ip):
 
 def is_valid_ip_path(ssh_path):
     """Check if SSH-PATH is a valid ssh path."""
-    pattern = r"^(?:([a-z_][a-z0-9_\.-]*)@)?((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?::(\d+))?:~?(.*)$"
+    pattern = r"^/?(?:([a-z_][a-z0-9_\.-]*)@)?((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?::(\d+))?:~?(.*)$"
     match = re.match(pattern, ssh_path)
     return match is not None
 
 def split_ssh_path(ssh_path):
     """Split SSH-PATH into username, host, port and path."""
-    pattern = r"^((?:([a-z_][a-z0-9_\.-]*)@)?((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?::(\d+))?):?(.*)$"
+    pattern = r"^/?((?:([a-z_][a-z0-9_\.-]*)@)?((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?::(\d+))?):?(.*)$"
     match = re.match(pattern, ssh_path)
     if match:
         remote_info, username, host, port, path = match.groups()

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -2686,7 +2686,12 @@ SSH tramp file name is like /ssh:user@host#port:path"
                                                                         lsp-bridge-remote-file-path))))
         (lsp-bridge-sync-tramp-remote)))))
 
+(defvar lsp-bridge-remote-file-window nil)
 (defun lsp-bridge-open-remote-file--response(tramp-method user host port path content position)
+  (if lsp-bridge-remote-file-window
+      (progn
+        (select-window lsp-bridge-remote-file-window)
+        (setq lsp-bridge-remote-file-window nil)))
   (let ((buf-name (format "[LBR] %s" (file-name-nondirectory path))))
     (lsp-bridge-define--jump-record-postion)
 
@@ -2726,7 +2731,10 @@ SSH tramp file name is like /ssh:user@host#port:path"
 
     ;; Always enable lsp-bridge for remote file.
     ;; Remote file can always edit and update content even some file haven't corresponding lsp server, such as *.txt
-    (lsp-bridge-mode 1)))
+    (lsp-bridge-mode 1))
+  (if lsp-bridge-ref-open-remote-file-go-back-to-ref-window
+      (lsp-bridge-switch-to-ref-window))
+  )
 
 (defun lsp-bridge-remote-kill-buffer ()
   (when lsp-bridge-remote-file-flag

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -229,21 +229,16 @@ class LspBridge:
 
         import paramiko
 
-        server_username = self.host_names[server_host]["username"]
-        server_ssh_port = self.host_names[server_host]["ssh_port"]
+        ssh_conf = self.host_names[server_host]
         try:
             client = RemoteFileClient(
-                server_host,
-                server_username,
-                server_ssh_port,
+                ssh_conf,
                 server_port,
                 lambda message: self.receive_remote_message(message, server_port),
-                self.host_names[server_host]["use_gssapi"],
-                self.host_names[server_host]["proxy_command"]
             )
         except paramiko.AuthenticationException:
             # cloud not login server
-            message_emacs(f"login {server_username}@{server_host}:{server_ssh_port} failed, please check *lsp-bridge*")
+            message_emacs(f"login {ssh_conf} failed, please check *lsp-bridge*")
             return None
 
         try:
@@ -330,32 +325,25 @@ class LspBridge:
     @threaded
     def sync_tramp_remote(self, tramp_file_name, server_username, server_host, ssh_port, path):
         # arguments are passed from emacs using standard TRAMP functions tramp-file-name-<field>
-        use_gssapi = False
-        proxy_command = None
-        alias = None
         if not is_valid_ip(server_host):
             alias = server_host
             if alias in self.host_names:
-                server_host = self.host_names[alias]["server_host"]
-                server_username = self.host_names[alias]["username"]
-                ssh_port = self.host_names[alias]["ssh_port"]
-                use_gssapi = self.host_names[alias]["use_gssapi"]
-                proxy_command = self.host_names[alias]["proxy_command"]
+                server_host = self.host_names[alias]['hostname']
+                ssh_conf = self.host_names[server_host]
             else:
                 import paramiko
                 ssh_config = paramiko.SSHConfig()
                 with open(os.path.expanduser('~/.ssh/config')) as f:
                     ssh_config.parse(f)
-                conf = ssh_config.lookup(alias)
+                ssh_conf = ssh_config.lookup(alias)
 
-                server_host = conf.get('hostname', server_host)
-                server_username = conf.get('user', server_username)
-                ssh_port = conf.get('port', ssh_port)
-                use_gssapi = conf.get('gssapiauthentication', 'no') in ('yes')
-                proxy_command = conf.get('proxycommand', None)
+                server_host = ssh_conf['hostname']
+                if server_username:
+                    ssh_conf['user'] = server_username
+                if ssh_port:
+                    ssh_conf['port'] = ssh_port
 
-                self.host_names[alias] = {"server_host": server_host, "username": server_username, "ssh_port": ssh_port, "use_gssapi": use_gssapi,
-                                          "proxy_command": proxy_command}
+                self.host_names[alias] = self.host_names[server_host] = ssh_conf
 
         if not is_valid_ip(server_host):
             message_emacs("HostName Must be IP format.")
@@ -364,20 +352,6 @@ class LspBridge:
         # it should not be called tramp-method to avoid confusion
         # we call it TRAMP connection information
         tramp_connection_info = tramp_file_name.rsplit(":", 1)[0] + ":"
-
-        if not server_username:
-            if server_host in self.host_names:
-                server_username = self.host_names[server_host]["username"]
-            else:
-                server_username = "root"
-
-        if not ssh_port:
-            if server_host in self.host_names:
-                ssh_port = self.host_names[server_host]["ssh_port"]
-            else:
-                ssh_port = 22
-
-        self.host_names[server_host] = {"username": server_username, "ssh_port": ssh_port, "use_gssapi": use_gssapi, "proxy_command": proxy_command}
 
         client_id = f"{server_host}:{REMOTE_FILE_ELISP_CHANNEL}"
         if client_id not in self.client_dict:
@@ -403,32 +377,15 @@ class LspBridge:
             # ip:port:path
             path_info = split_ssh_path(path)
             if path_info:
-                (server_username, server_host, ssh_port, server_path) = path_info
+                (remote_info, server_host, ssh_conf, server_path) = path_info
 
-                if not server_username:
-                    if server_host in self.host_names:
-                        server_username = self.host_names[server_host]["username"]
-                    else:
-                        server_username = "root"
-
-                if not ssh_port:
-                    if server_host in self.host_names:
-                        ssh_port = self.host_names[server_host]["ssh_port"]
-                    else:
-                        ssh_port = 22
-
-                self.host_names[server_host] = {
-                    "username": server_username,
-                    "ssh_port": ssh_port,
-                    "use_gssapi": False,
-                    "proxy_command": None
-                }
+                self.host_names[server_host] = ssh_conf
 
                 client_id = f"{server_host}:{REMOTE_FILE_ELISP_CHANNEL}"
                 if client_id not in self.client_dict:
                     # send "say hello" upon establishing the first connection
                     self.send_remote_message(server_host, self.remote_file_elisp_sender_queue, "Connect", True)
-                message_emacs(f"Open {server_username}@{server_host}#{ssh_port}:{server_path}...")
+                message_emacs(f"Open {remote_info}:{server_path}...")
                 # Add TRAMP-related fields
                 # The following fields: tramp_method, user, server, port, and path
                 # are set as buffer-local variables in the buffer created by Emacs.
@@ -439,13 +396,13 @@ class LspBridge:
                     server_host, self.remote_file_sender_queue, {
                     "command": "open_file",
                     "tramp_method": "ssh",
-                    "user": server_username,
+                    "user": ssh_conf.get('user'),
                     "server": server_host,
-                    "port": ssh_port,
+                    "port": ssh_conf.get('port'),
                     "path": server_path,
                     "jump_define_pos": epc_arg_transformer(jump_define_pos)
                 })
-                save_ip(f"{server_username}@{server_host}:{ssh_port}")
+                save_ip(f"{remote_info}")
         else:
             message_emacs("Please input valid path match rule: 'ip:/path/file'.")
 


### PR DESCRIPTION
1. Tweak the keys of the dict `host_names` storing ssh connection info so it will be compatible with class `paramiko.config.SSHConfigDict` which inherits the internal dict.
2. Also update remote information when `open_remote_file` in order to support jumping to references without using tramp.
