### PR TITLE
Fix some bugs for remote connection

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -402,7 +402,7 @@ def is_valid_ip_path(ssh_path):
 
 def split_ssh_path(ssh_path):
     """Split SSH-PATH into username, host, port and path."""
-    pattern = r"^/?((?:([a-z_][a-z0-9_\.-]*)@)?((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?::(\d+))?):?(.*)$"
+    pattern = r"^/?((?:([a-z_][a-z0-9_\.-]*)@)?((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?::(\d+))?:?)(.*)$"
     match = re.match(pattern, ssh_path)
     if match:
         remote_info, username, host, port, path = match.groups()

--- a/lsp-bridge-ref.el
+++ b/lsp-bridge-ref.el
@@ -850,7 +850,8 @@ user more freedom to use rg with special arguments."
                  (window-valid-p lsp-bridge-ref-request-search-window))
             (select-window lsp-bridge-ref-request-search-window)
           (other-window 1))
-        (if (and (not lsp-bridge-enable-with-tramp) (file-remote-p match-file))
+        (if (and (not lsp-bridge-enable-with-tramp)
+                 (string-match-p lsp-bridge-remote-file-pattern match-file))
             (progn
               (setq lsp-bridge-remote-file-window (selected-window))
               (setq lsp-bridge-ref-open-remote-file-go-back-to-ref-window (not stay))

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -2578,6 +2578,17 @@ We need exclude `markdown-code-fontification:*' buffer in `lsp-bridge-monitor-be
 (defvar-local lsp-bridge-remote-file-host nil)
 (defvar-local lsp-bridge-remote-file-port nil)
 (defvar-local lsp-bridge-remote-file-path nil)
+(defvar lsp-bridge-remote-file-pattern
+  (rx bos (? "/")
+      ;; username
+      (? (seq (any "a-z_") (* (any "a-z0-9_.-"))) "@")
+      ;; host ip
+      (repeat 3 (seq (repeat 1 3 (any "0-9")) ".")) (repeat 1 3 (any "0-9"))
+      ;; ssh port
+      (? ":" (+ digit))
+      ;; path
+      (? ":") (? "~") (* nonl) eol
+      ))
 
 (defun lsp-bridge-open-or-create-file (filepath)
   "Open FILEPATH, if it exists. If not, create it and its parent directories."
@@ -2742,7 +2753,9 @@ SSH tramp file name is like /ssh:user@host#port:path"
     ;; Remote file can always edit and update content even some file haven't corresponding lsp server, such as *.txt
     (lsp-bridge-mode 1))
   (if lsp-bridge-ref-open-remote-file-go-back-to-ref-window
-      (lsp-bridge-switch-to-ref-window))
+      (progn
+        (lsp-bridge-switch-to-ref-window)
+        (setq lsp-bridge-ref-open-remote-file-go-back-to-ref-window nil)))
   )
 
 (defun lsp-bridge-remote-kill-buffer ()

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -340,7 +340,7 @@ class LspBridge:
     def sync_tramp_remote(self, tramp_file_name, server_username, server_host, ssh_port, path):
         # arguments are passed from emacs using standard TRAMP functions tramp-file-name-<field>
         if server_host in self.host_names:
-            server_host = self.host_names[alias]['hostname']
+            server_host = self.host_names[server_host]['hostname']
             ssh_conf = self.host_names[server_host]
         elif is_valid_ip(server_host):
             ssh_conf = {'hostname' : server_host}
@@ -387,9 +387,9 @@ class LspBridge:
 
                 self.host_names[server_host] = ssh_conf
 
-                self.remote_sync(server_host, f"/{remote_info}:")
+                self.remote_sync(server_host, f"/{remote_info}")
 
-                message_emacs(f"Open {remote_info}:{server_path}...")
+                message_emacs(f"Open {remote_info}{server_path}...")
                 # Add TRAMP-related fields
                 # The following fields: tramp_method, user, server, port, and path
                 # are set as buffer-local variables in the buffer created by Emacs.


### PR DESCRIPTION
1. replace file-remote-p with string-match-p to support non-tramp usage.
2. clear the var `lsp-bridge-ref-open-remote-file-go-back-to-ref-window` after jump.
3. use `server_host` as key if it is already in host_names.
4. tweak the regular expression for remote file.