### PR TITLE
A fixup for the completion of snippets

### DIFF
--- a/acm/acm-backend-lsp.el
+++ b/acm/acm-backend-lsp.el
@@ -166,14 +166,7 @@ Recommand use `normal' that follow LSP server response, emacser's behavior typic
                           (acm-backend-lsp-snippet-expansion-fn)))
          ;; Default, delete-bound is from menu popup postion to cursor postion.
          (delete-start-pos bound-start)
-         (delete-end-pos (point))
-         ;; We record indent offset of first line,
-         ;; make sure last line of snippet is same indent as first line.
-         (snippet-indent-offset (save-excursion
-                                  (back-to-indentation)
-                                  (buffer-substring-no-properties
-                                   (line-beginning-position)
-                                   (point)))))
+         (delete-end-pos (point)))
 
     ;; Try to adjust delete-bound if `text-edit' is not nil.
     (when text-edit
@@ -219,7 +212,7 @@ Recommand use `normal' that follow LSP server response, emacser's behavior typic
         (save-excursion
           (goto-char yas-snippet-end)
           (goto-char (line-beginning-position))
-          (insert snippet-indent-offset)))
+          (indent-according-to-mode)))
       ;; Do `additional-text-edits' if return auto-imprt information.
       (when (and acm-backend-lsp-enable-auto-import
                  (cl-plusp (length additional-text-edits)))


### PR DESCRIPTION
将输入特定的缩进改为直接调用 `indent-according-to-mode` ，以避免重复插入缩进。