### PR TITLE
Close all files in remote server when client disconnects

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -688,17 +688,18 @@ class LspServer:
 
         # We need shutdown LSP server when last file closed, to save system memory.
         if len(self.files) == 0:
-            self.send_shutdown_request()
-            self.send_exit_notification()
-
             self.message_queue.put({
                 "name": "server_process_exit",
                 "content": self.server_name
             })
+            self.exit()
 
-            # Don't need to wait LSP server response, kill immediately.
-            if self.lsp_subprocess is not None:
-                try:
-                    os.kill(self.lsp_subprocess.pid, 9)
-                except ProcessLookupError:
-                    log_time("LSP server {} ({}) already exited!".format(self.server_info["name"], self.lsp_subprocess.pid))
+    def exit(self):
+        self.send_shutdown_request()
+        self.send_exit_notification()
+        # Don't need to wait LSP server response, kill immediately.
+        if self.lsp_subprocess is not None:
+            try:
+                os.kill(self.lsp_subprocess.pid, 9)
+            except ProcessLookupError:
+                log_time("LSP server {} ({}) already exited!".format(self.server_info["name"], self.lsp_subprocess.pid))

--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -331,6 +331,9 @@ class FileSyncServer(RemoteFileServer):
         if path in self.file_dict:
             del self.file_dict[path]
 
+    def close_all_files(self):
+        self.file_dict.clear()
+
 
 class FileElispServer(RemoteFileServer):
     def __init__(self, host, port, lsp_bridge):
@@ -381,6 +384,10 @@ class FileCommandServer(RemoteFileServer):
         self.lsp_bridge.init_search_backends_complete_event.wait()
 
         super().handle_client()
+
+        # close all files when client disconnects
+        self.lsp_bridge.file_server.close_all_files()
+        self.lsp_bridge.close_all_files()
 
     def handle_message(self, message):
         if message["command"] == "lsp_request":

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -616,6 +616,13 @@ class LspBridge:
         if is_in_path_dict(FILE_ACTION_DICT, filepath):
             get_from_path_dict(FILE_ACTION_DICT, filepath).exit()
 
+    def close_all_files(self):
+        FILE_ACTION_DICT.clear()
+
+        for lsp_server in LSP_SERVER_DICT.values():
+            lsp_server.exit()
+        LSP_SERVER_DICT.clear()
+
     def enjoy_hacking(self, servers, project_path):
         # Notify user server is ready.
         print("Start lsp server ({}) for {}".format(", ".join(servers), project_path))


### PR DESCRIPTION
If client emacs exits directly, function `close_file` will not be called by client. So we just close all files when client disconnects.