### PR TITLE
fix: always set diagnostics for first paint of flycheck/flymake update

### DIFF
--- a/lsp-bridge-diagnostic.el
+++ b/lsp-bridge-diagnostic.el
@@ -186,8 +186,7 @@ You can set this value with `(2 3 4) if you just need render error diagnostic."
   (lsp-bridge--with-file-buffer filepath filehost
                                 (setq-local lsp-bridge-diagnostic-count diagnostic-count)
 
-                                (unless lsp-bridge-diagnostic-enable-overlays
-                                  (setq-local lsp-bridge-diagnostic-records diagnostics))
+                                (setq-local lsp-bridge-diagnostic-records diagnostics)
 
                                 (run-hooks 'lsp-bridge-diagnostic-update-hook)
 


### PR DESCRIPTION
since flycheck / flymake can be enabled later with some interactive functions depending on the use cases.

with the `(unless lsp-bridge-diagnostic-enable-overlays)` check, the diagnostics are not available until the users start typing anything to trigger some lsp command.

if there wasn't a good reason (memory? maybe?), can we always enable it?