### PR TITLE
Fix completion error "Wrong type argument: integer-or-marker-p, nil"

### DIFF
--- a/acm/acm-backend-lsp.el
+++ b/acm/acm-backend-lsp.el
@@ -210,7 +210,6 @@ Recommand use `normal' that follow LSP server response, emacser's behavior typic
       ;; Indent last line of snippet, make sure it same as first line of snippet.
       (when snippet-fn
         (save-excursion
-          (goto-char yas-snippet-end)
           (goto-char (line-beginning-position))
           (indent-according-to-mode)))
       ;; Do `additional-text-edits' if return auto-imprt information.


### PR DESCRIPTION
Remove unused `goto-char yas-snippet-end` in `acm-backend-lsp.el` which cause completion failure.