### PR TITLE
remove face for renaming symbol

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1835,7 +1835,7 @@ Off by default."
 (defun lsp-bridge-rename ()
   (interactive)
   (lsp-bridge-call-file-api "prepare_rename" (lsp-bridge--position))
-  (let ((new-name (read-string "Rename to: " (thing-at-point 'symbol 'no-properties))))
+  (let ((new-name (substring-no-properties (read-string "Rename to: " (thing-at-point 'symbol 'no-properties)))))
     (lsp-bridge-call-file-api "rename" (lsp-bridge--position) new-name)))
 
 (defun lsp-bridge-flash-region (start-pos end-pos)


### PR DESCRIPTION
need to remove face before sending request, otherwise:

```
--- [14:29:49.199701] Recv textDocument/signatureHelp response (63102) from 'typescript' for project test-lsp
args ({'line': 272, 'character': 10}, Symbol('#'), ['Rotate90', 0, 1, [Symbol('face'), Symbol('tree-sitter-hl-face:comment')], 1, 3, [Symbol('face'), Symbol('tree-sitter-hl-face:comment')], 3, 4, [Symbol('face'), Symbol('tree-sitter-hl-face:comment')], 4, 7, [Symbol('face'), Symbol('tree-sitter-hl-face:comment')], 7, 8, [Symbol('rear-nonsticky'), True, Symbol('face'), Symbol('tree-sitter-hl-face:comment')]]) kwargs {}
Traceback (most recent call last):
  File "/home/user/.emacs.d/straight/build/lsp-bridge/lsp_bridge.py", line 517, in event_dispatcher
    self.event_queue.task_done()
  File "/home/user/.emacs.d/straight/build/lsp-bridge/lsp_bridge.py", line 778, in _do
    setattr(self, "_{}".format(name), _do)
  File "/home/user/.emacs.d/straight/repos/lsp-bridge/core/fileaction.py", line 163, in call
    self.send_request(method_server, method, handler, *args, **kwargs)
  File "/home/user/.emacs.d/straight/repos/lsp-bridge/core/fileaction.py", line 174, in send_request
    self.send_server_request(method_server, method, *args, **kwargs)
  File "/home/user/.emacs.d/straight/repos/lsp-bridge/core/fileaction.py", line 437, in send_server_request
    params = handler.process_request(*args, **kwargs)
TypeError: process_request() takes 3 positional arguments but 4 were given

```