### PR TITLE
feat: add emacs-jupyter completion backend for acm in org babel

### DIFF
--- a/acm/acm-backend-jupyter.el
+++ b/acm/acm-backend-jupyter.el
@@ -1,0 +1,34 @@
+;;; acm-backend-jupyter.el --- acm codeium support -*- lexical-binding: t; no-byte-compile: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+(defgroup acm-backend-jupyter nil
+  "ACM codeium support."
+  :group 'acm)
+
+(defcustom acm-enable-jupyter nil
+  "Enable codeium support."
+  :type 'boolean
+  :group 'acm-backend-jupyter)
+
+(defvar-local acm-backend-jupyter-items nil)
+
+(defun acm-backend-jupyter-candidates (keyword)
+  (acm-with-cache-candidates
+   acm-backend-jupyter-cache-candiates
+   (acm-candidate-sort-by-prefix
+    keyword
+    acm-backend-jupyter-items)))
+
+(defun lsp-bridge-jupyter-record (candidates)
+  (setq-local acm-backend-jupyter-items candidates)
+  (lsp-bridge-try-completion))
+
+(defun acm-backend-jupyter-clean ()
+  (setq-local acm-backend-jupyter-items nil)
+  (setq-local acm-backend-jupyter-cache-candiates nil))
+
+(provide 'acm-backend-jupyter)
+;;; acm-backend-jupyter.el ends here

--- a/acm/acm.el
+++ b/acm/acm.el
@@ -107,6 +107,7 @@
 (require 'acm-backend-codeium)
 (require 'acm-backend-copilot)
 (require 'acm-backend-org-roam)
+(require 'acm-backend-jupyter)
 (require 'acm-quick-access)
 
 ;;; Code:
@@ -458,6 +459,7 @@ Only calculate template candidate when type last character."
          tabnine-candidates
          codeium-candidates
          copilot-candidates
+         jupyter-candidates
          tempel-candidates
          mode-candidates
          mode-first-part-candidates
@@ -481,6 +483,9 @@ Only calculate template candidate when type last character."
     (when acm-enable-copilot
       (setq copilot-candidates (acm-backend-copilot-candidates keyword)))
 
+    (when acm-enable-jupyter
+      (setq jupyter-candidates (acm-backend-jupyter-candidates keyword)))
+
     (if acm-enable-search-sdcv-words
         ;; Completion SDCV if option `acm-enable-search-sdcv-words' is enable.
         (setq candidates (acm-backend-search-sdcv-words-candidates keyword))
@@ -500,6 +505,7 @@ Only calculate template candidate when type last character."
                                (unless (acm-in-comment-p) (acm-backend-tailwind-candidates keyword))
                                (unless (acm-in-comment-p) (acm-backend-elisp-candidates keyword))
                                lsp-candidates
+                               jupyter-candidates
                                ctags-candidates
                                citre-candidates
 			       org-roam-candidates

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1583,7 +1583,7 @@ So we build this macro to restore postion after code format."
                     (not (lsp-bridge-is-org-temp-buffer-p)))
                (org-in-src-block-p 'inside)
                (string-prefix-p "jupyter" (plist-get (car (cdr (org-element-context))) :language)))
-      (lsp-bridge-jupyter-complete))
+      (acm-backend-jupyter-record current-symbol))
 
     (when (and acm-enable-ctags
                (lsp-bridge-process-live-p))
@@ -2540,27 +2540,6 @@ We need exclude `markdown-code-fontification:*' buffer in `lsp-bridge-monitor-be
                              (not indent-tabs-mode)
                              (acm-get-input-prefix)
                              language))))
-
-(defun lsp-bridge-jupyter-complete ()
-  (interactive)
-  (unless (fboundp 'jupyter-org-completion-at-point)
-    (require 'jupyter)
-    (require 'jupyter-org-client)
-    (require 'ob-jupyter))
-  (setq-local acm-backend-jupyter-items nil)
-  (let* ((candidates (all-completions "" (nth 2 (jupyter-org-completion-at-point))))
-         (candidates-with-metadata (mapcar (lambda (candidate)
-                                             (let ((text (substring-no-properties candidate)))
-                                               (list :key text
-                                                     :icon ""
-                                                     :label text
-                                                     :displayLabel text
-                                                     :annotation "jupyter"
-                                                     :backend "jupyter")))
-                                           candidates)))
-    (when candidates
-      (lsp-bridge-search-backend--record-items "jupyter" candidates-with-metadata)
-      )))
 
 (defun lsp-bridge-copilot-complete ()
   (interactive)


### PR DESCRIPTION
# add a emacs-jupyter backend for acm babel completion

1. This backend can be activated by set `acm-enable-jupyter` to `t`
2. This backend only work when in a org-mode source code block and its language starts with `"jupyter"`
3. It still can make completion even though the `import` statement in a previous source code block
4. It need to start the jupyter in the org mode buffer first

![image](https://github.com/manateelazycat/lsp-bridge/assets/44355570/1cb72e06-1ccc-4170-8607-d8299ed8f90f)
