### PR TITLE
fix: check buffer-file-name before checking if file is remote

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1008,7 +1008,7 @@ So we build this macro to restore postion after code format."
 (defun lsp-bridge-call-file-api (method &rest args)
   (if (lsp-bridge-is-remote-file)
       (lsp-bridge-remote-send-lsp-request method args)
-    (if (file-remote-p (buffer-file-name))
+    (if (and buffer-file-name (file-remote-p (buffer-file-name)))
         (message "[LSP-Bridge] remote file \"%s\" is updating info... skip call %s."
                  (buffer-file-name) method)
       (when (lsp-bridge-call-file-api-p)


### PR DESCRIPTION
it errors when the cursor is on typescript server's `move to new file...` code action.

i guess it is trying to preview the action but since the action is moving to a new file, the `buffer-file-name` is `nil` in this case. this only fixes the symptom, i am not sure about the cause.