### PR TITLE
Sync tramp info

### DIFF
--- a/core/ctags.py
+++ b/core/ctags.py
@@ -25,6 +25,12 @@ DEFAULT_FILTER_CMD = '(not (or (and $extras ((string->regexp "(^|,) ?(anonymous|
 
 DEFAULT_SORTER_CMD = '(<or> (if (and $name &name) (<> (length $name) (length &name)) 0) (if (and $name &name) (<> $name &name) 0))'
 
+# for Python 3.9-
+def remove_prefix(text, prefix):
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text
+
 class Ctags:    
     def __init__(self) -> None:
         self.current_cursor_offset = 0
@@ -80,7 +86,7 @@ class Ctags:
         extras = tag.get("extras", "")
         reference = "<R>" if "reference" in extras else ""
 
-        typeref = typeref.removeprefix("typename:")
+        typeref = removeprefix(typeref, "typename:")
         typeref = re.sub(r'(^|:)(__anon[^:]+)(:|$)', r'\1__anon\3', typeref)
         scope = re.sub(r'(^|:)(__anon[^:]+)(:|$)', r'\1__anon\3', scope)
 

--- a/core/ctags.py
+++ b/core/ctags.py
@@ -86,7 +86,7 @@ class Ctags:
         extras = tag.get("extras", "")
         reference = "<R>" if "reference" in extras else ""
 
-        typeref = removeprefix(typeref, "typename:")
+        typeref = remove_prefix(typeref, "typename:")
         typeref = re.sub(r'(^|:)(__anon[^:]+)(:|$)', r'\1__anon\3', typeref)
         scope = re.sub(r'(^|:)(__anon[^:]+)(:|$)', r'\1__anon\3', scope)
 

--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -178,7 +178,8 @@ class RemoteFileClient(threading.Thread):
         _, stdout, stderr = self.ssh.exec_command(
             f"""
             nohup /bin/bash -l -c '
-            if ! pidof {remote_python_command} >/dev/null 2>&1; then
+            pid=$(ps aux | grep -v grep | grep lsp_bridge.py | cut -d " " -f2)
+            if [ "$pid" == "" ]; then
                 echo -e "Start lsp-bridge process as user $(whoami)" | tee >{remote_log}
                 {remote_python_command} {remote_python_file} >>{remote_log} 2>&1 &
                 if [ "$?" = "0" ]; then


### PR DESCRIPTION
1. Accelerate the tramp file opening speed on already connected remote machines.
2. Adapt the remove_prefix function for Python versions prior to 3.9.
3. Use "ps | grep " to determine if the lsp_bridge.py process has started to prevent misjudgment.