### PR TITLE
Add support for "tempel-trigger-prefix"

### DIFF
--- a/acm/acm-backend-tempel.el
+++ b/acm/acm-backend-tempel.el
@@ -16,8 +16,12 @@
 
 (defun acm-backend-tempel-candidates (keyword)
   (when (and acm-enable-tempel
-             (featurep 'tempel))
-    (let* ((snippets (cl-loop for template in (tempel--templates)
+             (featurep 'tempel)
+             (or (not tempel-trigger-prefix) (string-prefix-p tempel-trigger-prefix keyword)))
+    (let* ((keyword (if tempel-trigger-prefix
+                        (string-remove-prefix tempel-trigger-prefix keyword)
+                      keyword))
+           (snippets (cl-loop for template in (tempel--templates)
                               collect (format "%s" (car template))))
            (match-snippets (seq-filter (lambda (s) (acm-candidate-fuzzy-search keyword s)) snippets)))
       (acm-candidate-sort-by-prefix


### PR DESCRIPTION
The variable `tempel-trigger-prefix` controls which prefix need to be input first before the completion can recognize it. For example, if there is a snippet "header" returned by `tempel--templates`, with `tempel-trigger-prefix` set to "t", "theader" will then expand to the snippet body.

This variable should be respected by ACM too.

The effects:

With prefix set, no tempel completion options show up:

![image](https://github.com/manateelazycat/lsp-bridge/assets/93167100/02571b06-a233-4caa-80f6-45c0f79776e0)

If the prefix is entered, tempel snippets can be matched:

![image](https://github.com/manateelazycat/lsp-bridge/assets/93167100/7b13b071-979f-40b8-a376-0193ab479f21)

TAB, the completion expands:

![image](https://github.com/manateelazycat/lsp-bridge/assets/93167100/de216be5-d7a7-4c04-91df-56bca42d193c)
