### PR TITLE
fix: The name of the mode related to Clojure TS has been renamed.

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -532,9 +532,9 @@ Possible choices are pyright_ruff, pyright-background-analysis_ruff, jedi_ruff, 
       clojurescript-mode
       clojurex-mode
       clojure-ts-mode
-      clojurec-ts-mode
-      clojurescript-ts-mode
-      clojure-dart-ts-mode)  .                                                   "clojure-lsp")
+      clojure-ts-clojurec-mode
+      clojure-ts-clojurescript-mode
+      clojure-ts-clojuredart-mode)  .                                                   "clojure-lsp")
     ((sh-mode bash-mode bash-ts-mode) .                                          "bash-language-server")
     ((css-mode css-ts-mode) .                                                    "vscode-css-language-server")
     (elm-mode   .                                                                "elm-language-server")


### PR DESCRIPTION
https://github.com/clojure-emacs/clojure-ts-mode/blob/main/CHANGELOG.md#021-2024-02-14
![CleanShot 2024-04-26 at 10 07 48@2x](https://github.com/manateelazycat/lsp-bridge/assets/37489300/a05b5b65-19cb-434d-b22b-32fdaa8778af)
