### PR TITLE
Remove unused hashlib imports

### DIFF
--- a/core/handler/completion.py
+++ b/core/handler/completion.py
@@ -1,5 +1,4 @@
 import os
-import hashlib
 from enum import Enum
 from functools import cmp_to_key
 


### PR DESCRIPTION
Not deleted in https://github.com/manateelazycat/lsp-bridge/commit/f0eeb9ffbb363b6dd3ab675c57734db706c3393a.

-----

By the way, Python's default hashing algorithm has been replaced by SipHash13 since 3.11.
https://bugs.python.org/issue29410

I have not measured performance, but it is possible that the built-in [`hash`](https://docs.python.org/3/library/functions.html#hash) function may be superior to both `hashlib.md5` and a userland `fnv_1a` function in terms of collision resistance and performance when obtaining fixed-length hashes.