### PR TITLE
Fix `Codeaction` to `CodeAction`

### DIFF
--- a/core/fileaction.py
+++ b/core/fileaction.py
@@ -392,7 +392,7 @@ class FileAction:
                 diagnostics.append(diagnostic)
 
         self.send_request(
-            lsp_server, "code_action", Codeaction,
+            lsp_server, "code_action", CodeAction,
             lsp_server_name, diagnostics, range_start, range_end, action_kind
         )
 


### PR DESCRIPTION
I get:
```
--- [19:09:45.275665] Recv textDocument/signatureHelp response (32290) from 'rust-analyzer' for project
Traceback (most recent call last):
  File "/home/exec/.emacs.d/straight/build/lsp-bridge/lsp_bridge.py", line 512, in event_dispatcher
    getattr(self, func_name)(*func_args)
  File "/home/exec/.emacs.d/straight/build/lsp-bridge/lsp_bridge.py", line 773, in _do
    action.call(name, *args)
  File "/home/exec/Projects/github.com/manateelazycat/lsp-bridge/core/fileaction.py", line 166, in call
    getattr(self, method)(*args, **kwargs)
  File "/home/exec/Projects/github.com/manateelazycat/lsp-bridge/core/fileaction.py", line 264, in try_code_action
    self.send_code_action_request(self.single_server, *args, **kwargs)
  File "/home/exec/Projects/github.com/manateelazycat/lsp-bridge/core/fileaction.py", line 395, in send_code_action_request
    lsp_server, "code_action", Codeaction,
                               ^^^^^^^^^^
NameError: name 'Codeaction' is not defined

```

So I think the class name should be `CodeAction`:
https://github.com/manateelazycat/lsp-bridge/blob/ac8a331bf85e795b5d31bcc28bfc6032da42d425/core/handler/code_action.py#L5