### PR TITLE
Fix naming issues with copilot and codeium on Windows

### DIFF
--- a/core/copilot.py
+++ b/core/copilot.py
@@ -60,7 +60,7 @@ class Copilot:
             message_emacs('To use copilot, Please install node version >= 16')
             return
 
-        npm_package_path = subprocess.check_output(['npm', 'root', '-g'], universal_newlines=True).strip()
+        npm_package_path = subprocess.check_output(["npm.cmd" if get_os_name() == "windows" else "npm", 'root', '-g'], universal_newlines=True).strip()
         agent_path =  os.path.join(npm_package_path, "copilot-node-server", "copilot/dist/agent.js")
 
         self.copilot_subprocess = subprocess.Popen([self.node_path, agent_path],

--- a/lsp-bridge-lsp-installer.el
+++ b/lsp-bridge-lsp-installer.el
@@ -281,7 +281,11 @@ Only useful on GNU/Linux.  Automatically set if NixOS is detected."
          (compress-file (concat binary-dir file-name))
          (binary-file (string-trim-right compress-file "\\.gz"))
          ;; Binary file after rename
-         (last-binary-file (concat binary-dir "language_server"))
+         (last-binary-file (if (or (eq system-type 'ms-dos)
+                                   (eq system-type 'windows-nt)
+                                   (eq system-type 'cygwin))
+                               (concat binary-dir "language_server.exe")
+                             (concat binary-dir "language_server")))
          (download-url (concat codeium-download-url-prefix version "/" file-name)))
     (make-directory binary-dir t)
     (if (string= version codeium-bridge-binary-version)


### PR DESCRIPTION
Can't use copilot and codeium in Windows because of the name issue.