### PR TITLE
Fix insert_spaces type in codeium.py

### DIFF
--- a/core/codeium.py
+++ b/core/codeium.py
@@ -79,7 +79,7 @@ class Codeium:
                 "text": text,
                 "language": language,
             },
-            "editor_options": {"insert_spaces": insert_spaces, "tab_size": tab_size},
+            "editor_options": {"insert_spaces": True if insert_spaces else False, "tab_size": tab_size},
         }
 
         self.dispatch(


### PR DESCRIPTION
Sometimes `insert_spaces` is passed a list type parameter, which then causes codeium to crash. It needs to be of type bool.

![Clip_2024-06-01_03-19-43](https://github.com/manateelazycat/lsp-bridge/assets/92523839/c2240528-0ca6-45d7-8dfb-2b9d4ccfa3f6)
