### PR TITLE
Support connect to lsp-bridge server running in devcontainer

### DIFF
--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -23,6 +23,7 @@ import threading
 import os
 import glob
 import json
+import select
 import socket
 import traceback
 import time
@@ -30,6 +31,10 @@ from core.utils import *
 
 
 class SendMessageException(Exception):
+    pass
+
+
+class ContainerConnectionException(Exception):
     pass
 
 
@@ -195,6 +200,69 @@ class RemoteFileClient(threading.Thread):
         print("stderr:" + stderr.read().decode())
 
 
+class DockerFileClient(threading.Thread):
+    def __init__(self, container_name, server_port, callback):
+        threading.Thread.__init__(self)
+        self.container_name = container_name
+        self.server_port = server_port
+        self.callback = callback
+        self.sock = None
+        self.lock = threading.Lock()  # For thread-safe socket access
+
+        self.connect()
+
+    def connect(self):
+        """Connect to docker container
+
+        :raises: :class:`ContainerConnectionException`: if failed to connect
+        """
+        with self.lock:
+            try:
+                self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                # connect to local host
+                self.sock.connect(("127.0.0.1", self.server_port))
+            except Exception as e:
+                raise ContainerConnectionException(e)
+
+    def send_message(self, message):
+        """Send message via socket
+
+        :raises: :class:`SendMessageException`: if socket is invalid
+        """
+        try:
+            if self.sock.fileno == -1:
+                # container might be restarted, try to reconnect
+                time.sleep(1)
+                self.connect()
+
+            data = json.dumps(message)
+            self.sock.sendall(f"{data}\n".encode("utf-8"))
+
+        except Exception as e:
+            logger.exception(e)
+            raise e
+        else:
+            log_time_debug(f"Sended to server {self.container_name} port {self.server_port}: {message}")
+
+    def run(self):
+        """Continuously listen for incoming data from the server."""
+        try:
+            sock_file = self.sock.makefile("r")
+            while True:
+                message = sock_file.readline().strip()
+                if not message:
+                    break
+
+                message = parse_json_content(message)
+                message["host"] = self.container_name
+                log_time_debug(f"Received from server {self.container_name} port {self.server_port}: {message}")
+                self.callback(message)
+
+        except socket.error as e:
+            raise SendMessageException() from e
+        finally:
+            self.sock.close()
+
 class RemoteFileServer:
     def __init__(self, host, port):
         import socket
@@ -355,7 +423,7 @@ class FileElispServer(RemoteFileServer):
 
     def handle_message(self, message):
         if message == "Connect":
-            # Drop "say hello" message from local Emacs.
+            log_time("Drop 'say hello' message from local Emacs.")
             return
         else:
             self.result_queue.put(message)
@@ -413,6 +481,16 @@ def save_ip_to_file(ip, filename):
 
     with open(filename, 'w') as f:
         f.write('\n'.join(existing_ips))
+
+
+def get_container_local_ip(container_name):
+    try:
+        command = "docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' " + container_name
+        result = subprocess.check_output(command, shell=True, text=True).strip()
+        return result
+    except subprocess.CalledProcessError as e:
+        message_emacs(f"{traceback.format_exc()}")
+        return None
 
 
 def save_ip(ip):

--- a/core/utils.py
+++ b/core/utils.py
@@ -421,8 +421,20 @@ def split_ssh_path(ssh_path):
     else:
         return None
 
+def split_docker_path(docker_path):
+    # Pattern to extract username, container name, and path
+    pattern = r"^/docker:(?P<username>[^@]+)@(?P<container_name>[^:]+):(?P<path>/.*)$"
+    match = re.match(pattern, docker_path)
+    if match:
+        username = match.group('username')
+        container_name = match.group('container_name')
+        path = match.group('path')
+        return (username, container_name, path)
+    else:
+        return None
+
 def is_remote_path(filepath):
-    return filepath.startswith("/ssh:")
+    return filepath.startswith("/ssh:") or filepath.startswith("/docker:")
 
 def eval_sexp_in_emacs(sexp):
     epc_client.call("eval-in-emacs", [sexp])

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -266,21 +266,21 @@ After set `lsp-bridge-completion-obey-trigger-characters-p' to nil, you need use
 (defcustom lsp-bridge-user-langserver-dir nil
   "The directory where the user place langserver configuration."
   :type '(choice (const nil)
-                 (string))
+          (string))
   :safe (lambda (v) (or (null v) (stringp v)))
   :group 'lsp-bridge)
 
 (defcustom lsp-bridge-user-multiserver-dir nil
   "The directory where the user place multiserver configuration."
   :type '(choice (const nil)
-                 (string))
+          (string))
   :safe (lambda (v) (or (null v) (stringp v)))
   :group 'lsp-bridge)
 
 (defcustom lsp-bridge-user-ssh-private-key nil
   "custom SSH private key path for use in SSH connections."
   :type '(choice (const nil)
-                 (string))
+          (string))
   :safe (lambda (v) (or (null v) (stringp v)))
   :group 'lsp-bridge)
 
@@ -513,7 +513,7 @@ Possible choices are pyright_ruff, pyright-background-analysis_ruff, jedi_ruff, 
     ((python-mode python-ts-mode) .                                              lsp-bridge-python-lsp-server)
     ((ruby-mode ruby-ts-mode) .                                                  "solargraph")
     ((rust-mode rustic-mode rust-ts-mode) .                                      "rust-analyzer")
-	(move-mode .                                                                 "move-analyzer")
+    (move-mode .                                                                 "move-analyzer")
     ((elixir-mode elixir-ts-mode heex-ts-mode) .                                 lsp-bridge-elixir-lsp-server)
     ((go-mode go-ts-mode) .                                                      "gopls")
     (groovy-mode .                                                               "groovy-language-server")
@@ -726,7 +726,7 @@ you can customize `lsp-bridge-get-workspace-folder' to return workspace folder p
     (enh-ruby-mode              . enh-ruby-indent-level) ; Ruby
     (crystal-mode               . crystal-indent-level) ; Crystal (Ruby)
     (css-mode                   . css-indent-offset)    ; CSS
-	(move-mode                  . move-indent-offset)   ; Move
+    (move-mode                  . move-indent-offset)   ; Move
     (rust-mode                  . rust-indent-offset)   ; Rust
     (rust-ts-mode               . rust-ts-mode-indent-offset) ; Rust
     (rustic-mode                . rustic-indent-offset)       ; Rust
@@ -781,7 +781,9 @@ you can customize `lsp-bridge-get-workspace-folder' to return workspace folder p
 
 (defun lsp-bridge-find-file-hook-function ()
   (when (and lsp-bridge-enable-with-tramp (file-remote-p (buffer-file-name)))
-    (lsp-bridge-sync-tramp-remote)))
+    (lsp-bridge-sync-tramp-remote)
+    (when (string-prefix-p "/docker:" (buffer-file-name))
+      (lsp-bridge-call-async "open_remote_file" (buffer-file-name) (list :line 0 :character 0)))))
 
 (add-hook 'find-file-hook #'lsp-bridge-find-file-hook-function)
 
@@ -840,7 +842,10 @@ So we build this macro to restore postion after code format."
       (when (and (boundp 'lsp-bridge-remote-file-path)
                  (string-equal lsp-bridge-remote-file-path path)
                  (boundp 'lsp-bridge-remote-file-host)
-                 (string-equal lsp-bridge-remote-file-host host))
+                 (or (string-equal lsp-bridge-remote-file-host host)
+                     ;; host is "127.0.0.1" sent from get_lsp_file_host() when server running inside container
+                     ;; client connect to lsp bridge server from local host
+                     (string-equal "127.0.0.1" host)))
         (cl-return buffer)))))
 
 (defun lsp-bridge-get-match-buffer-by-filepath (name)
@@ -1872,10 +1877,10 @@ Off by default."
 (defun lsp-bridge-find-def-fallback (position)
   (if (not (= (length lsp-bridge-peek-ace-list) 0))
       (progn
-	    (if (nth 0 lsp-bridge-peek-ace-list)
-	        (kill-buffer (nth 0 lsp-bridge-peek-ace-list)))
-	    (switch-to-buffer (nth 2 lsp-bridge-peek-ace-list))
-	    (goto-char (nth 1 lsp-bridge-peek-ace-list))))
+	(if (nth 0 lsp-bridge-peek-ace-list)
+	    (kill-buffer (nth 0 lsp-bridge-peek-ace-list)))
+	(switch-to-buffer (nth 2 lsp-bridge-peek-ace-list))
+	(goto-char (nth 1 lsp-bridge-peek-ace-list))))
   (message "[LSP-Bridge] No definition found.")
   (if (functionp lsp-bridge-find-def-fallback-function)
       (funcall lsp-bridge-find-def-fallback-function position)))
@@ -2342,8 +2347,8 @@ SymbolKind (defined in the LSP)."
   "Looks up the symbol under the cursor. If there's a marked region, use that instead."
   (interactive)
   (if (region-active-p)
-	  (lsp-bridge-workspace-list-symbols (buffer-substring-no-properties (mark) (point)))
-	(lsp-bridge-workspace-list-symbols (substring-no-properties (symbol-name (symbol-at-point))))))
+      (lsp-bridge-workspace-list-symbols (buffer-substring-no-properties (mark) (point)))
+    (lsp-bridge-workspace-list-symbols (substring-no-properties (symbol-name (symbol-at-point))))))
 
 (defun lsp-bridge-workspace-list-symbols (query)
   (interactive "sWorkspace symbol query: ")
@@ -2756,7 +2761,7 @@ the context of that buffer. If the buffer is created by
      ;; lsp-bridge--with-file-buffer is another macro, carefully expand it
      ,(macroexpand `(lsp-bridge--with-file-buffer ,path ,host ,@body))))
 
-(defun lsp-bridge-update-tramp-file-info (tramp-file-name tramp-connection-info host path)
+(defun lsp-bridge-update-tramp-file-info (tramp-file-name tramp-connection-info tramp-method user host path)
   (unless (assoc host lsp-bridge-tramp-alias-alist)
     (push `(,host . ,tramp-connection-info) lsp-bridge-tramp-alias-alist))
 
@@ -2765,6 +2770,8 @@ the context of that buffer. If the buffer is created by
 
   (lsp-bridge--conditional-update-tramp-file-info tramp-file-name path host
                                                   (setq-local lsp-bridge-remote-file-flag t)
+                                                  (setq-local lsp-bridge-remote-file-tramp-method tramp-method)
+                                                  (setq-local lsp-bridge-remote-file-user user)
                                                   (setq-local lsp-bridge-remote-file-host host)
                                                   (setq-local lsp-bridge-remote-file-path path)
 
@@ -2810,9 +2817,11 @@ I haven't idea how to make lsp-bridge works with `electric-indent-mode', PR are 
         (when (and (not (member tramp-method '("sudo" "sudoedit" "su" "doas")))
                    (not (member host lsp-bridge-tramp-blacklist)))
           (read-only-mode 1)
-          (lsp-bridge-call-async "sync_tramp_remote" file-name user host port path))
+          (lsp-bridge-call-async "sync_tramp_remote" file-name tramp-method user host port path))
       (lsp-bridge--conditional-update-tramp-file-info file-name path ip-host
                                                       (setq-local lsp-bridge-remote-file-flag t)
+                                                      (setq-local lsp-bridge-remote-file-tramp-method tramp-method)
+                                                      (setq-local lsp-bridge-remote-file-user user)
                                                       (setq-local lsp-bridge-remote-file-host ip-host)
                                                       (setq-local lsp-bridge-remote-file-path path)
 
@@ -2897,6 +2906,19 @@ SSH tramp file name is like /ssh:user@host#port:path"
     ;; Always enable lsp-bridge for remote file.
     ;; Remote file can always edit and update content even some file haven't corresponding lsp server, such as *.txt
     (lsp-bridge-mode 1))
+
+  (when (string-equal tramp-method "docker")
+    (let ((tramp-filename (lsp-bridge-construct-tramp-file-name lsp-bridge-remote-file-tramp-method
+                                                                lsp-bridge-remote-file-user
+                                                                lsp-bridge-remote-file-host
+                                                                lsp-bridge-remote-file-port
+                                                                lsp-bridge-remote-file-path)))
+      ;; use `find-file' to open TRAMP docker file will open a tramp buffer, kill it
+      (kill-buffer (get-file-buffer tramp-filename))
+      ;; set the name of the file visited in the current buffer
+      ;; the next time the buffer is saved it will go in the tramp file
+      (set-visited-file-name tramp-filename t t)))
+
   (when lsp-bridge-ref-open-remote-file-go-back-to-ref-window
     (lsp-bridge-switch-to-ref-window)
     (setq lsp-bridge-ref-open-remote-file-go-back-to-ref-window nil)))

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -46,11 +46,14 @@ from core.utils import *
 from core.handler import *
 from core.remote_file import (
     RemoteFileClient,
+    DockerFileClient,
     FileSyncServer,
     FileElispServer,
     FileCommandServer,
     SendMessageException,
-    save_ip
+    ContainerConnectionException,
+    save_ip,
+    get_container_local_ip
 )
 from core.ctags import Ctags
 
@@ -67,11 +70,6 @@ REMOTE_FILE_SYNC_CHANNEL = 9999
 REMOTE_FILE_COMMAND_CHANNEL = 9998
 REMOTE_FILE_ELISP_CHANNEL = 9997
 
-remote_server_ports = [
-    REMOTE_FILE_SYNC_CHANNEL,
-    REMOTE_FILE_COMMAND_CHANNEL,
-    REMOTE_FILE_ELISP_CHANNEL
-]
 
 class LspBridge:
     def __init__(self, args):
@@ -199,7 +197,9 @@ class LspBridge:
 
     @threaded
     def init_remote_file_server(self):
-        print("* Running lsp-bridge in remote server, use command 'lsp-bridge-open-remote-file' to open remote file.")
+        print("* Running lsp-bridge in remote server, "
+              "use command 'lsp-bridge-open-remote-file' to open remote file, "
+              "or 'find-file' /docker: to open file in running container.")
 
         # Build loop for remote files management.
         self.file_server = FileSyncServer("0.0.0.0", REMOTE_FILE_SYNC_CHANNEL)
@@ -211,6 +211,17 @@ class LspBridge:
 
     # Functions for communication between local and remote server
     def get_socket_client(self, server_host, server_port, is_retry=False):
+        # currently only support SSH and docker
+        #
+        # try to distinguish SSH remote file or docker remote file using server_host
+        # if visiting docker remote file, container name is passed as server_host
+        if is_valid_ip(server_host):
+            return self._get_remtoe_file_client(server_host, server_port, is_retry)
+        else:
+            # server_host is the container_name
+            return self._get_docker_file_client(server_host, server_port)
+
+    def _get_remtoe_file_client(self, server_host, server_port, is_retry):
         if server_host not in self.host_names:
             message_emacs(f"{server_host} is not connected, try reconnect...")
             self.sync_tramp_remote_complete_event.clear()
@@ -258,8 +269,26 @@ class LspBridge:
         else:
             client.start()
             self.client_dict[client_id] = client
+            return client
 
-        return client
+    def _get_docker_file_client(self, container_name, server_port):
+        client_id = f"{container_name}:{server_port}"
+        if client_id in self.client_dict:
+            return self.client_dict[client_id]
+
+        try:
+            client = DockerFileClient(
+                container_name=container_name,
+                server_port=server_port,
+                callback=lambda message: self.receive_remote_message(message, server_port),
+            )
+        except ContainerConnectionException as e:
+            print(f"Failed to connect {container_name}, is it running?")
+            raise e
+        else:
+            client.start()
+            self.client_dict[client_id] = client
+            return client
 
     def send_remote_message(self, host, queue, message, wait=False):
         queue.put({"host": host, "message": message})
@@ -277,20 +306,20 @@ class LspBridge:
                     client.send_message(data["message"])
                 except SendMessageException as e:
                     # lsp-bridge process might has been restarted, making the orignal socket no longer valid.
-                    logger.exception("Channel %s is broken, message %s, error %s", f"{server_host}:{port}", data["message"], e)
+                    logger.exception("Connection %s is broken, message %s, error %s", f"{server_host}:{port}", data["message"], e)
                     # remove all the clients for server_host from client_dict
                     # client will be created again when get_socket_client is called
-                    for p in remote_server_ports:
-                        self.client_dict.pop(f"{server_host}:{p}", None)
+                    for client_id in [key for key in self.client_dict.keys() if key.startswith(server_host + ":")]:
+                        self.client_dict.pop(client_id, None)
 
-                    message_emacs(f"try to recreate channel to {server_host}:{port}")
+                    message_emacs(f"try to recreate connection to {server_host}:{port}")
                     try:
                         client = self.get_socket_client(server_host, port)
                     except Exception as e:
-                        # unable to restore the channel
+                        # FATAL: unable to restore
                         logger.exception(e)
                     else:
-                        # try to send the message
+                        # connection restored, try to send out the message
                         client.send_message(data["message"])
                         eval_in_emacs('lsp-bridge-remote-reconnect', server_host)
                 except Exception as e:
@@ -317,7 +346,7 @@ class LspBridge:
         except:
             logger.error(traceback.format_exc())
 
-    def remote_sync(self, host, remote_info):
+    def remote_sync(self, host, remote_connection_info):
         client_id = f"{host}:{REMOTE_FILE_ELISP_CHANNEL}"
         if client_id not in self.client_dict:
             # send "say hello" upon establishing the first connection
@@ -328,46 +357,91 @@ class LspBridge:
                 host, self.remote_file_sender_queue, {
                     "command": "remote_sync",
                     "server": host,
-                    "remote_connection_info": remote_info,
+                    "remote_connection_info": remote_connection_info,
                 })
 
     @threaded
-    def sync_tramp_remote(self, tramp_file_name, server_username, server_host, ssh_port, path):
-        # arguments are passed from emacs using standard TRAMP functions tramp-file-name-<field>
-        if server_host in self.host_names:
-            server_host = self.host_names[server_host]['hostname']
-            ssh_conf = self.host_names[server_host]
-        elif is_valid_ip(server_host):
-            ssh_conf = {'hostname' : server_host}
+    def sync_tramp_remote(self, tramp_file_name, tramp_method, server_username, server_host, ssh_port, path):
+
+        # tramp_file_name format example:
+        #   /ssh:user@ip#port:/path/to/file
+        #   /docker:user@container:/path/to/file
+        # see https://www.gnu.org/software/tramp/#File-name-syntax
+        tramp_method_prefix = tramp_file_name.rsplit(":", 1)[0]
+
+        if tramp_method_prefix.startswith("/ssh"):
+
+            # arguments are passed from emacs using standard TRAMP functions tramp-file-name-<field>
+            if server_host in self.host_names:
+                server_host = self.host_names[server_host]['hostname']
+                ssh_conf = self.host_names[server_host]
+            elif is_valid_ip(server_host):
+                ssh_conf = {'hostname' : server_host}
+            else:
+                import paramiko
+                alias = server_host
+                ssh_config = paramiko.SSHConfig()
+                with open(os.path.expanduser('~/.ssh/config')) as f:
+                    ssh_config.parse(f)
+                ssh_conf = ssh_config.lookup(alias)
+
+                server_host = ssh_conf.get('hostname', server_host)
+                self.host_names[alias] = ssh_conf
+
+            if not is_valid_ip(server_host):
+                message_emacs("HostName Must be IP format.")
+
+            if server_username:
+                ssh_conf['user'] = server_username
+            if ssh_port:
+                ssh_conf['port'] = ssh_port
+            self.host_names[server_host] = ssh_conf
+
+            tramp_connection_info = tramp_method_prefix + ":"
+            self.remote_sync(server_host, tramp_connection_info)
+
+            eval_in_emacs("lsp-bridge-update-tramp-file-info", tramp_file_name, tramp_connection_info, tramp_method, server_username, server_host, path)
+            self.sync_tramp_remote_complete_event.set()
+
+        elif tramp_method_prefix.startswith("/docker"):
+            # when using tramp to connect to container, the tramp_file_name might be
+            #
+            # /docker:USER@CONTAINER:/path/to/file
+            # /docker:CONTAINER:/path/to/file
+            #
+            # see https://git.savannah.gnu.org/git/tramp.git listp/tramp-container.el
+            tramp_method_split = tramp_method_prefix.split(":")[1]
+            if "@" in tramp_method_split:
+                container_user, container_name = tramp_method_split.split("@")
+            else:
+                container_user = "root"
+                container_name = tramp_method_split
+
+            if not get_container_local_ip(container_name):
+                message_emacs(f"Cloud not get local ip of container {container_name}, is it running?")
+                return
+
+            # only support local container
+            self.host_names[container_name] = {
+                "server_host": "127.0.0.1",
+                "username": container_user
+            }
+
+            try:
+                tramp_connection_info = tramp_method_prefix + ":"
+                self.remote_sync(container_name, tramp_connection_info)
+                # container_name is used for emacs buffer local variable lsp-bridge-remote-file-host
+                eval_in_emacs("lsp-bridge-update-tramp-file-info", tramp_file_name, tramp_connection_info, tramp_method, container_user, container_name, path)
+                self.sync_tramp_remote_complete_event.set()
+            except Exception as e:
+                logger.exception(e)
+                message_emacs(f"Connect {container_user}@{container_name} failed")
+                raise e
         else:
-            import paramiko
-            alias = server_host
-            ssh_config = paramiko.SSHConfig()
-            with open(os.path.expanduser('~/.ssh/config')) as f:
-                ssh_config.parse(f)
-            ssh_conf = ssh_config.lookup(alias)
-
-            server_host = ssh_conf.get('hostname', server_host)
-            self.host_names[alias] = ssh_conf
-
-        if not is_valid_ip(server_host):
-            message_emacs("HostName Must be IP format.")
-
-        if server_username:
-            ssh_conf['user'] = server_username
-        if ssh_port:
-            ssh_conf['port'] = ssh_port
-        self.host_names[server_host] = ssh_conf
-
-        # this value is like /ssh:user@ip#port:
-        # it should not be called tramp-method to avoid confusion
-        # we call it TRAMP connection information
-        tramp_connection_info = tramp_file_name.rsplit(":", 1)[0] + ":"
-
-        self.remote_sync(server_host, tramp_connection_info)
-
-        eval_in_emacs("lsp-bridge-update-tramp-file-info", tramp_file_name, tramp_connection_info, server_host, path)
-        self.sync_tramp_remote_complete_event.set()
+            message_emacs(
+                f"Failed to access {tramp_file_name}, unsupported tramp methd: {tramp_method_prefix[1:]}, "
+                "please make sure `lsp_bridge.py` has started on server."
+            )
 
     # Functions for local to manage remote files
     @threaded
@@ -402,6 +476,34 @@ class LspBridge:
                     "jump_define_pos": epc_arg_transformer(jump_define_pos)
                 })
                 save_ip(f"{remote_info}")
+        elif path.startswith("/docker:"):
+            # open_remote_file path notation
+            # /docker:user@container:/path/to/file
+            # /docker:container:/path/to/file
+            path_info = split_docker_path(path)
+            if path_info:
+                (container_user, server_host, server_path) = path_info
+
+                # only support local container
+                self.host_names[server_host] = {
+                    "server_host": "127.0.0.1",
+                    "username": container_user
+                }
+
+                self.remote_sync(server_host, path.rsplit(":", 1)[0] + ":")
+
+                message_emacs(f"Open {path}...")
+
+                self.send_remote_message(
+                    server_host, self.remote_file_sender_queue, {
+                        "command": "open_file",
+                        "tramp_method": "docker",
+                        "user": container_user,
+                        "server": server_host,
+                        "port": None,
+                        "path": server_path,
+                        "jump_define_pos": epc_arg_transformer(jump_define_pos)
+                })
         else:
             message_emacs("Please input valid path match rule: 'ip:/path/file'.")
 


### PR DESCRIPTION
Long story short, here are screenshots of lsp-bridge connecting to lsp-bridge server running inside [devcontainer](https://containers.dev/), this will definitely help the editing expereince of using Emacs to access files inside docker container.

## running on `emacs -q`

<img width="1144" alt="Screenshot 2024-06-08 at 6 40 21 PM" src="https://github.com/manateelazycat/lsp-bridge/assets/149959021/19943bac-c7de-4109-812c-0cd155191b3d">

## running on `doom-emacs`

<img width="1283" alt="Screenshot 2024-06-09 at 4 08 41 PM" src="https://github.com/manateelazycat/lsp-bridge/assets/149959021/c30fe3cb-d90c-440b-b17b-463fe1989943">

## instructions
Please see [my other project](https://github.com/nohzafk/devcontainer-feature-emacs-lsp-bridge) about the instructions of using lsp-bridge in devcontainer.

## curent limitation
When container is restarted, opened buffers are no longer valid, automatically reconnect like `open remote SSH file` is not supported.