### PR TITLE
Container: handle visitied file modtime & Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ It should be noted that lsp-bridge has three scanning modes:
 
 ## Remote Usage
 
+### Remote SSH server
 `lsp-bridge` can perform code syntax completion on files on a remote server, similar to VSCode. The configuration steps are as follows:
 
 1. Install lsp-bridge and the corresponding LSP Server on the remote server.
@@ -138,6 +139,86 @@ Note:
 3. To run lsp_bridge.py successfully you need to completely download the entire git repository of lsp-bridge on a remote server, and switch into its directory, lsp_bridge.py requires other files to function properly, so copying only the lsp_bridge.py file can't work
 4. If a tramp file encounters an lsp-bridge connection error, you can execute the `lsp-bridge-tramp-show-hostnames` function and then check if the output of the host configuration options meets expectations
 
+### Local devcontainer
+`lsp-bridge` now support completion on files on `devcontainer`, similar to VSCode. This is done by using [devcontainer-feature-emacs-lsp-bridge](https://github.com/nohzafk/devcontainer-feature-emacs-lsp-bridge).
+
+Here is a compelte configuration example
+
+#### devcontainer.json
+`.devcontainer/devcontainer.json`
+
+``` json
+{
+    "name": "Node.js & TypeScript",
+    // Your base image
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/nohzafk/devcontainer-feature-emacs-lsp-bridge/pyright-background-analysis_ruff:latest": {}
+    },
+    "forwardPorts": [
+        9997,
+        9998,
+        9999
+    ],
+    // More info: https://aka.ms/dev-containers-non-root.
+    "remoteUser": "root"
+}
+```
+
+#### doom-emacs configuration
+`config.el`
+
+``` elisp
+(use-package! lsp-bridge
+  :config
+  (setq lsp-bridge-python-multi-lsp-server "pyright-background-analysis_ruff")
+
+  (global-lsp-bridge-mode))
+```
+
+start the devcontainer and use `file-find` `/docker:user@container:/path/to/file` to open the file.
+
+more detail please refer to [devcontainer-feature-emacs-lsp-bridge](https://github.com/nohzafk/devcontainer-feature-emacs-lsp-bridge).
+
+If you use `apheleia` as formatter, `lsp-bridge` now support auto formatting file on devcontainer.
+
+```elsip
+(use-package! apheleia
+  :config
+  (setq +format-with-lsp nil)
+  ;; which formatter to use
+  (setf (alist-get 'python-mode apheleia-mode-alist) 'ruff)
+  (setf (alist-get 'python-ts-mode apheleia-mode-alist) 'ruff)
+
+  (setq apheleia-remote-algorithm 'local)
+  (after! lsp-bridge
+    (add-hook 'apheleia-post-format-hook #'lsp-bridge-update-tramp-docker-file-mod-time)))
+```
+
+### goodness
+Use [topsy](https://github.com/alphapapa/topsy.el) to remind you that you're editing a remote file.
+
+#### doom-emacs configuration example
+`packages.el`
+```elisp
+(package! topsy)
+```
+
+`config.el`
+```
+(use-package! topsy
+    :config
+    (after! lsp-bridge
+      (setcdr (assoc nil topsy-mode-functions)
+              (lambda ()
+                (when (lsp-bridge-is-remote-file) "[LBR] REMOTE FILE")))
+
+      ;; do not activate when the current major mode is org-mode
+      (add-hook 'lsp-bridge-mode-hook (lambda ()
+                                        (unless (derived-mode-p 'org-mode)
+                                          (topsy-mode 1))))))
+```                                          
 
 ## Keymap
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,6 +105,7 @@ lsp-bridge 开箱即用， 安装好语言对应的 [LSP 服务器](https://gith
 
 ## 远程使用
 
+### 远程 SSH 服务器
 `lsp-bridge`能像 VSCode 一样在远程服务器文件上进行代码语法补全。 配置步骤如下：
 
 1. 在远程服务器安装 lsp-bridge 和相应的 LSP Server
@@ -134,6 +135,91 @@ lsp-bridge 开箱即用， 安装好语言对应的 [LSP 服务器](https://gith
 2. lsp-bridge 会用`~/.ssh`的第一个 *.pub 文件作为登录凭证。 如果公钥登录失败， 会要求输入密码。 lsp-bridge 不会存储密码， 建议用公钥登录以避免重复输入密码
 3. 你需要在远程服务器完整的下载整个 lsp-bridge git 仓库， 并切换到 lsp-bridge 目录来启动 `lsp_bridge.py`， `lsp_bridge.py` 需要其他文件来保证正常工作， 不能只把 `lsp_bridge.py` 文件拷贝到其他目录来启动
 4. 如果 tramp 文件出现 lsp-bridge 连接错误， 可以执行 `lsp-bridge-tramp-show-hostnames` 函数， 然后检查输出的 host 配置选项是否符合预期
+
+Here is the translation of the technical description to Chinese:
+
+### 本地开发容器
+
+`lsp-bridge` 现在支持在 `devcontainer` 上的文件补完，类似于 VSCode。这是通过使用 [devcontainer-feature-emacs-lsp-bridge](https://github.com/nohzafk/devcontainer-feature-emacs-lsp-bridge) 实现的。
+
+以下是一个完整的配置示例：
+
+#### devcontainer.json
+`.devcontainer/devcontainer.json`
+
+```json
+{
+    "name": "Node.js & TypeScript",
+    // Your base image
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/nohzafk/devcontainer-feature-emacs-lsp-bridge/pyright-background-analysis_ruff:latest": {}
+    },
+    "forwardPorts": [
+        9997,
+        9998,
+        9999
+    ],
+    // More info: https://aka.ms/dev-containers-non-root.
+    "remoteUser": "root"
+}
+```
+
+#### Doom Emacs 配置
+`config.el`
+
+```elisp
+(use-package! lsp-bridge
+  :config
+  (setq lsp-bridge-python-multi-lsp-server "pyright-background-analysis_ruff")
+
+  (global-lsp-bridge-mode))
+```
+
+启动开发容器，并使用 `file-find` `/docker:user@container:/path/to/file` 打开文件。
+
+更多详细信息，请参阅 [devcontainer-feature-emacs-lsp-bridge](https://github.com/nohzafk/devcontainer-feature-emacs-lsp-bridge)。
+
+如果您使用 `apheleia` 作为 Formatter，`lsp-bridge` 现在支持自动格式化 devcontainer 上的文件。
+
+```elisp
+(use-package! apheleia
+  :config
+  (setq +format-with-lsp nil)
+  ;; 设置 Formatter
+  (setf (alist-get 'python-mode apheleia-mode-alist) 'ruff)
+  (setf (alist-get 'python-ts-mode apheleia-mode-alist) 'ruff)
+
+  (setq apheleia-remote-algorithm 'local)
+  (after! lsp-bridge
+    (add-hook 'apheleia-post-format-hook #'lsp-bridge-update-tramp-docker-file-mod-time)))
+```
+
+### 编辑远程文件提示
+
+使用 [topsy](https://github.com/alphapapa/topsy.el) 提醒您正在编辑远程文件。
+
+#### Doom Emacs 配置示例
+`packages.el`
+```elisp
+(package! topsy)
+```
+
+`config.el`
+```elisp
+(use-package! topsy
+    :config
+    (after! lsp-bridge
+      (setcdr (assoc nil topsy-mode-functions)
+              (lambda ()
+                (when (lsp-bridge-is-remote-file) "[LBR] 远程文件")))
+
+      ;; 当前主要模式为 org-mode 时不激活
+      (add-hook 'lsp-bridge-mode-hook (lambda ()
+                                        (unless (derived-mode-p 'org-mode)
+                                          (topsy-mode 1))))))
+```
 
 ## 按键
 

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1780,8 +1780,24 @@ So we build this macro to restore postion after code format."
 (defun lsp-bridge-completion-ui-visible-p ()
   (acm-frame-visible-p acm-menu-frame))
 
+(defun lsp-bridge-update-tramp-docker-file-mod-time ()
+  "Updaet buffer visited file mode time."
+  ;; set-visited-file-name associate a buffer with a file path.
+  ;; file timestamps are handled or recognized by Emacs through TRAMP.
+  ;; discrepancies of file timestamps will make Emacs warn about file has been
+  ;; changed since visited or saved.
+  (when (string-prefix-p "/docker:" buffer-file-name)
+    (let* ((file-name (lsp-bridge-get-buffer-file-name-text))
+           (tramp-vec (tramp-dissect-file-name file-name))
+           (path (tramp-file-name-localname tramp-vec))
+           (host (tramp-file-name-host tramp-vec)))
+      (lsp-bridge--conditional-update-tramp-file-info file-name path host
+                                                      (set-visited-file-modtime
+                                                       (file-attribute-modification-time (file-attributes buffer-file-name)))))))
+
 (defun lsp-bridge-monitor-after-save ()
-  (lsp-bridge-call-file-api "save_file" (buffer-name)))
+  (lsp-bridge-call-file-api "save_file" (buffer-name))
+  (lsp-bridge-update-tramp-docker-file-mod-time))
 
 (defcustom lsp-bridge-find-def-fallback-function nil
   "Fallback for find definition failure."
@@ -2917,7 +2933,10 @@ SSH tramp file name is like /ssh:user@host#port:path"
       (kill-buffer (get-file-buffer tramp-filename))
       ;; set the name of the file visited in the current buffer
       ;; the next time the buffer is saved it will go in the tramp file
-      (set-visited-file-name tramp-filename t t)))
+      (set-visited-file-name tramp-filename t t)
+      ;; auto reload the file content if formatter made change
+      ;; otherwise when saving file emacs will warn file has been changed on disk
+      (auto-revert-mode 1)))
 
   (when lsp-bridge-ref-open-remote-file-go-back-to-ref-window
     (lsp-bridge-switch-to-ref-window)


### PR DESCRIPTION
Editng container file:
- Handle visitied file modified time, so emacs won't warn about file has been changed since visited or saved.
- Support auto refresh file content when formatter format the file

Update README 
- how to enable lsp-bridge devcontainer
- how to enable formatting container file
- how to add a reminder that currently editing a remote file
