### PR TITLE
feat: support treesit ts mode for csharp

### DIFF
--- a/acm/acm-backend-codeium.el
+++ b/acm/acm-backend-codeium.el
@@ -66,7 +66,6 @@
 	(c++-mode . 4)
 	(c++-ts-mode . 4)
 	(csharp-mode . 5)
-	(csharp-tree-sitter-mode . 5)
 	(csharp-ts-mode . 5)
 	(css-mode . 6)
 	(css-ts-mode . 6)

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -735,7 +735,6 @@ you can customize `lsp-bridge-get-workspace-folder' to return workspace folder p
     (c++-mode                   . c-basic-offset) ; C++
     (markdown-mode              . c-basic-offset) ; Markdown.
     (csharp-mode                . c-basic-offset) ; C#
-    (csharp-tree-sitter-mode    . csharp-tree-sitter-indent-offset) ; C#
     (csharp-ts-mode             . csharp-ts-mode-indent-offset) ; C#
     (d-mode                     . c-basic-offset)             ; D
     (julia-mode                 . c-basic-offset)             ; Julia

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -565,7 +565,7 @@ Possible choices are basedpyright_ruff, pyright_ruff, pyright-background-analysi
     (ess-r-mode .                                                                "rlanguageserver")
     ((graphql-mode graphql-ts-mode) .                                            "graphql-lsp")
     (swift-mode .                                                                "swift-sourcekit")
-    (csharp-mode .                                                               lsp-bridge-csharp-lsp-server)
+    ((csharp-mode csharp-ts-mode) .                                              lsp-bridge-csharp-lsp-server)
     (kotlin-mode .                                                               "kotlin-language-server")
     (verilog-mode .                                                              "verible")
     (vhdl-mode .                                                                 "vhdl-tool")
@@ -658,6 +658,7 @@ Possible choices are basedpyright_ruff, pyright_ruff, pyright-background-analysi
     verilog-mode-hook
     swift-mode-hook
     csharp-mode-hook
+    csharp-ts-mode-hook
     telega-chat-mode-hook
     markdown-mode-hook
     kotlin-mode-hook
@@ -735,6 +736,7 @@ you can customize `lsp-bridge-get-workspace-folder' to return workspace folder p
     (markdown-mode              . c-basic-offset) ; Markdown.
     (csharp-mode                . c-basic-offset) ; C#
     (csharp-tree-sitter-mode    . csharp-tree-sitter-indent-offset) ; C#
+    (csharp-ts-mode             . csharp-ts-mode-indent-offset) ; C#
     (d-mode                     . c-basic-offset)             ; D
     (julia-mode                 . c-basic-offset)             ; Julia
     (java-mode                  . c-basic-offset)             ; Java


### PR DESCRIPTION
Adds support for the csharp tree-sitter mode included with emacs.

Also removes references to `csharp-tree-sitter-mode`, which is part of https://github.com/emacs-csharp/csharp-mode. It's been merged into emacs core and is no longer maintained as a separate repo.