### PR TITLE
resolve race condition of get_buffer_content trying to read file content before handle_open_file finished

### DIFF
--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -424,7 +424,6 @@ class FileSyncServer(RemoteFileServer):
                         "content": content
                     })
                     self.file_dict[path] = content
-                    print("file_dict after handle_open_file: " + str(self.file_dict.keys()))
         else:
             response.update({
                 "path": path,

--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -27,6 +27,7 @@ import socket
 import traceback
 import time
 from core.utils import *
+from contextlib import contextmanager
 
 
 class SendMessageException(Exception):
@@ -360,8 +361,9 @@ class RemoteFileServer:
 
 class FileSyncServer(RemoteFileServer):
     def __init__(self, host, port):
-        self.file_dict = {}
         super().__init__(host, port)
+        self.file_dict = {}
+        self.file_locks = {}
 
     def handle_message(self, message):
         command = message["command"]
@@ -379,26 +381,50 @@ class FileSyncServer(RemoteFileServer):
         elif command == "update_file":
             return self.handle_update_file(message)
 
+    @contextmanager
+    def file_access_lock(self, path):
+        path = os.path.abspath(os.path.expanduser(path))
+
+        # even though messages arrive in sequence, there are edge cases:
+        # - change_file message comes before handle_open_file finishes.
+        # - utils.get_buffer_content utils.get_file_content_from_file_server
+        #   try to read file content before handle_open_file finishes.
+        #
+        # Add a threading.Lock() for each file operation to ensure atomic access.
+        lock = self.file_locks.setdefault(path, threading.Lock())
+        try:
+            lock.acquire()
+            yield
+        finally:
+            lock.release()
+
+    def get_file_content(self, path):
+        with self.file_access_lock(path):
+            return self.file_dict.get(path, "")
+
     def handle_update_file(self, message):
-        path = os.path.expanduser(message["path"])
-        self.file_dict[path] = message["content"]
+        path = message["path"]
+        with self.file_access_lock(path):
+            self.file_dict[path] = message["content"]
 
     def handle_remote_sync(self, message):
         remote_info = message["remote_connection_info"]
         set_remote_connection_info(remote_info)
 
     def handle_open_file(self, message):
-        path = os.path.expanduser(message["path"])
+        path = message["path"]
         response = {**message, "path": path}
 
         if os.path.exists(path):
-            with open(path) as f:
-                content = f.read()
-                response.update({
-                    "path": path,
-                    "content": content
-                })
-                self.file_dict[path] = content
+            with self.file_access_lock(path):
+                with open(path) as f:
+                    content = f.read()
+                    response.update({
+                        "path": path,
+                        "content": content
+                    })
+                    self.file_dict[path] = content
+                    print("file_dict after handle_open_file: " + str(self.file_dict.keys()))
         else:
             response.update({
                 "path": path,
@@ -410,24 +436,28 @@ class FileSyncServer(RemoteFileServer):
 
     def handle_change_file(self, message):
         path = message["path"]
-        if path not in self.file_dict:
-            with open(path) as f:
-                self.file_dict[path] = f.read()
 
-        self.file_dict[path] = rebuild_content_from_diff(self.file_dict[path], message["args"][0], message["args"][1], message["args"][3])
+        with self.file_access_lock(path):
+            if path not in self.file_dict:
+                with open(path) as f:
+                    self.file_dict[path] = f.read()
+
+            self.file_dict[path] = rebuild_content_from_diff(self.file_dict[path], message["args"][0], message["args"][1], message["args"][3])
 
     def handle_save_file(self, message):
         path = message["path"]
 
         if path in self.file_dict:
-            with open(path, 'w') as file:
-                file.write(self.file_dict[path])
+            with self.file_access_lock(path):
+                with open(path, 'w') as file:
+                    file.write(self.file_dict[path])
 
     def handle_close_file(self, message):
         path = message["path"]
 
         if path in self.file_dict:
-            del self.file_dict[path]
+            with self.file_access_lock(path):
+                del self.file_dict[path]
 
     def close_all_files(self):
         self.file_dict.clear()

--- a/core/utils.py
+++ b/core/utils.py
@@ -126,15 +126,15 @@ def get_buffer_content(filename, buffer_name):
     global lsp_bridge_server
 
     if lsp_bridge_server and lsp_bridge_server.file_server:
-        return lsp_bridge_server.file_server.file_dict[filename]
+        return lsp_bridge_server.file_server.get_file_content(filename)
     else:
         return get_emacs_func_result('get-buffer-content', buffer_name)
 
 def get_file_content_from_file_server(filename):
     global lsp_bridge_server
 
-    if lsp_bridge_server and lsp_bridge_server.file_server and filename in lsp_bridge_server.file_server.file_dict:
-        return lsp_bridge_server.file_server.file_dict[filename]
+    if lsp_bridge_server and lsp_bridge_server.file_server:
+        return lsp_bridge_server.file_server.get_file_content(filename)
     else:
         return ""
 


### PR DESCRIPTION
Testing lsp-bridge in container gives me more edge case

This error happens constantly,  get_buffer_content is trying to read file content before handle_open_file finished, when it happens, lsp stops working, that's why I'm having trouble using language server inside container.

We need to wrap the file access opeartion with lock to ensure the access is atomatic.

error log
```log
Traceback (most recent call last):
  File "/tmp/lsp-bridge/lsp_bridge.py", line 625, in event_dispatcher
    getattr(self, func_name)(*func_args)
  File "/tmp/lsp-bridge/lsp_bridge.py", line 886, in _do
    action.call(name, *args)
  File "/nix/store/f8ki1wxp84nj1nldjlj50y5wm5qknyn9-lsp-bridge-src-20240717-master/core/fileaction.py", line 166, in call
    getattr(self, method)(*args, **kwargs)
  File "/nix/store/f8ki1wxp84nj1nldjlj50y5wm5qknyn9-lsp-bridge-src-20240717-master/core/fileaction.py", line 191, in change_file
    buffer_content = get_buffer_content(self.filepath, buffer_name)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/f8ki1wxp84nj1nldjlj50y5wm5qknyn9-lsp-bridge-src-20240717-master/core/utils.py", line 129, in get_buffer_content
    return lsp_bridge_server.file_server.file_dict[filename]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: '/workspaces/the_gleam_learner/test/flat_tensor_test.gleam'
```

With this change, the error no long happen, and language server works good, close #997 