### PR TITLE
handle lang_server is empty list

### DIFF
--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -424,7 +424,6 @@ class FileSyncServer(RemoteFileServer):
                         "content": content
                     })
                     self.file_dict[path] = content
-                    print("file_dict after handle_open_file: " + str(self.file_dict.keys()))
         else:
             response.update({
                 "path": path,

--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -27,6 +27,7 @@ import socket
 import traceback
 import time
 from core.utils import *
+from contextlib import contextmanager
 
 
 class SendMessageException(Exception):
@@ -360,8 +361,9 @@ class RemoteFileServer:
 
 class FileSyncServer(RemoteFileServer):
     def __init__(self, host, port):
-        self.file_dict = {}
         super().__init__(host, port)
+        self.file_dict = {}
+        self.file_locks = {}
 
     def handle_message(self, message):
         command = message["command"]
@@ -379,26 +381,50 @@ class FileSyncServer(RemoteFileServer):
         elif command == "update_file":
             return self.handle_update_file(message)
 
+    @contextmanager
+    def file_access_lock(self, path):
+        path = os.path.abspath(os.path.expanduser(path))
+
+        # even though messages arrive in sequence, there are edge cases:
+        # - change_file message comes before handle_open_file finishes.
+        # - utils.get_buffer_content utils.get_file_content_from_file_server
+        #   try to read file content before handle_open_file finishes.
+        #
+        # Add a threading.Lock() for each file operation to ensure atomic access.
+        lock = self.file_locks.setdefault(path, threading.Lock())
+        try:
+            lock.acquire()
+            yield
+        finally:
+            lock.release()
+
+    def get_file_content(self, path):
+        with self.file_access_lock(path):
+            return self.file_dict.get(path, "")
+
     def handle_update_file(self, message):
-        path = os.path.expanduser(message["path"])
-        self.file_dict[path] = message["content"]
+        path = message["path"]
+        with self.file_access_lock(path):
+            self.file_dict[path] = message["content"]
 
     def handle_remote_sync(self, message):
         remote_info = message["remote_connection_info"]
         set_remote_connection_info(remote_info)
 
     def handle_open_file(self, message):
-        path = os.path.expanduser(message["path"])
+        path = message["path"]
         response = {**message, "path": path}
 
         if os.path.exists(path):
-            with open(path) as f:
-                content = f.read()
-                response.update({
-                    "path": path,
-                    "content": content
-                })
-                self.file_dict[path] = content
+            with self.file_access_lock(path):
+                with open(path) as f:
+                    content = f.read()
+                    response.update({
+                        "path": path,
+                        "content": content
+                    })
+                    self.file_dict[path] = content
+                    print("file_dict after handle_open_file: " + str(self.file_dict.keys()))
         else:
             response.update({
                 "path": path,
@@ -410,24 +436,28 @@ class FileSyncServer(RemoteFileServer):
 
     def handle_change_file(self, message):
         path = message["path"]
-        if path not in self.file_dict:
-            with open(path) as f:
-                self.file_dict[path] = f.read()
 
-        self.file_dict[path] = rebuild_content_from_diff(self.file_dict[path], message["args"][0], message["args"][1], message["args"][3])
+        with self.file_access_lock(path):
+            if path not in self.file_dict:
+                with open(path) as f:
+                    self.file_dict[path] = f.read()
+
+            self.file_dict[path] = rebuild_content_from_diff(self.file_dict[path], message["args"][0], message["args"][1], message["args"][3])
 
     def handle_save_file(self, message):
         path = message["path"]
 
         if path in self.file_dict:
-            with open(path, 'w') as file:
-                file.write(self.file_dict[path])
+            with self.file_access_lock(path):
+                with open(path, 'w') as file:
+                    file.write(self.file_dict[path])
 
     def handle_close_file(self, message):
         path = message["path"]
 
         if path in self.file_dict:
-            del self.file_dict[path]
+            with self.file_access_lock(path):
+                del self.file_dict[path]
 
     def close_all_files(self):
         self.file_dict.clear()

--- a/core/utils.py
+++ b/core/utils.py
@@ -126,15 +126,15 @@ def get_buffer_content(filename, buffer_name):
     global lsp_bridge_server
 
     if lsp_bridge_server and lsp_bridge_server.file_server:
-        return lsp_bridge_server.file_server.file_dict[filename]
+        return lsp_bridge_server.file_server.get_file_content(filename)
     else:
         return get_emacs_func_result('get-buffer-content', buffer_name)
 
 def get_file_content_from_file_server(filename):
     global lsp_bridge_server
 
-    if lsp_bridge_server and lsp_bridge_server.file_server and filename in lsp_bridge_server.file_server.file_dict:
-        return lsp_bridge_server.file_server.file_dict[filename]
+    if lsp_bridge_server and lsp_bridge_server.file_server:
+        return lsp_bridge_server.file_server.get_file_content(filename)
     else:
         return ""
 

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -990,7 +990,7 @@ def read_lang_server_info(lang_server_path):
 
 def load_single_server_info(lang_server):
     lang_server_info_path = ""
-    if os.path.exists(lang_server) and os.path.dirname(lang_server) != "":
+    if isinstance(lang_server, str) and os.path.exists(lang_server) and os.path.dirname(lang_server) != "":
         # If lang_server is real file path, we load the LSP server configuration from the user specified file.
         lang_server_info_path = lang_server
     else:


### PR DESCRIPTION
fix when lang_server is empty list

```log
file_dict after handle_open_file: 
Traceback (most recent call last):
  File "/tmp/lsp-bridge/lsp_bridge.py", line 625, in event_dispatcher
    getattr(self, func_name)(*func_args)
  File "/tmp/lsp-bridge/lsp_bridge.py", line 879, in _do
    open_file_success = self.open_file(filepath)  # _do is called inside event_loop, so we can block here.
                        ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/lsp-bridge/lsp_bridge.py", line 658, in open_file
    lang_server_info = load_single_server_info(single_lang_server)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/lsp-bridge/lsp_bridge.py", line 994, in load_single_server_info
    if os.path.exists(lang_server) and os.path.dirname(lang_server) != "":
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen genericpath>", line 19, in exists
TypeError: stat: path should be string, bytes, os.PathLike or integer, not list
```
when this error happens, lang_server is `[]`, we should add the isinstance condition to avoid error.

Otherwise error will stop lsp-bridge from working when using inside a container.