### PR TITLE
works with apheleia to auto-format remote docker file

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ Here is a compelte configuration example
 
 ``` json
 {
-    "name": "Node.js & TypeScript",
+    "name": "Ubuntu",
     // Your base image
-    "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
-        "ghcr.io/nohzafk/devcontainer-feature-emacs-lsp-bridge/pyright-background-analysis_ruff:latest": {}
+        "ghcr.io/nohzafk/devcontainer-feature-emacs-lsp-bridge/gleam:latest": {}
     },
     "forwardPorts": [
         9997,
@@ -163,7 +163,7 @@ Here is a compelte configuration example
         9999
     ],
     // More info: https://aka.ms/dev-containers-non-root.
-    "remoteUser": "root"
+    "remoteUser": "vscode"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,7 @@ If you use `apheleia` as formatter, `lsp-bridge` now support auto formatting fil
   (setf (alist-get 'python-ts-mode apheleia-mode-alist) 'ruff)
 
   (setq apheleia-remote-algorithm 'local)
-  (after! lsp-bridge
-    (add-hook 'apheleia-post-format-hook #'lsp-bridge-update-tramp-docker-file-mod-time)))
+  (setq apheleia-post-format-hook #'lsp-bridge-monitor-after-save))
 ```
 
 ## Keymap

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -148,12 +148,12 @@ lsp-bridge 开箱即用， 安装好语言对应的 [LSP 服务器](https://gith
 
 ```json
 {
-    "name": "Node.js & TypeScript",
+    "name": "Ubuntu",
     // Your base image
-    "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
-        "ghcr.io/nohzafk/devcontainer-feature-emacs-lsp-bridge/pyright-background-analysis_ruff:latest": {}
+        "ghcr.io/nohzafk/devcontainer-feature-emacs-lsp-bridge/gleam:latest": {}
     },
     "forwardPorts": [
         9997,
@@ -161,7 +161,7 @@ lsp-bridge 开箱即用， 安装好语言对应的 [LSP 服务器](https://gith
         9999
     ],
     // More info: https://aka.ms/dev-containers-non-root.
-    "remoteUser": "root"
+    "remoteUser": "vscode"
 }
 ```
 
@@ -175,13 +175,12 @@ lsp-bridge 开箱即用， 安装好语言对应的 [LSP 服务器](https://gith
 (use-package! apheleia
   :config
   (setq +format-with-lsp nil)
-  ;; 设置 Formatter
+  ;; which formatter to use
   (setf (alist-get 'python-mode apheleia-mode-alist) 'ruff)
   (setf (alist-get 'python-ts-mode apheleia-mode-alist) 'ruff)
 
   (setq apheleia-remote-algorithm 'local)
-  (after! lsp-bridge
-    (add-hook 'apheleia-post-format-hook #'lsp-bridge-update-tramp-docker-file-mod-time)))
+  (setq apheleia-post-format-hook #'lsp-bridge-monitor-after-save))
 ```
 
 ## 按键

--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -424,7 +424,6 @@ class FileSyncServer(RemoteFileServer):
                         "content": content
                     })
                     self.file_dict[path] = content
-                    print("file_dict after handle_open_file: " + str(self.file_dict.keys()))
         else:
             response.update({
                 "path": path,

--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -27,6 +27,7 @@ import socket
 import traceback
 import time
 from core.utils import *
+from contextlib import contextmanager
 
 
 class SendMessageException(Exception):
@@ -360,8 +361,9 @@ class RemoteFileServer:
 
 class FileSyncServer(RemoteFileServer):
     def __init__(self, host, port):
-        self.file_dict = {}
         super().__init__(host, port)
+        self.file_dict = {}
+        self.file_locks = {}
 
     def handle_message(self, message):
         command = message["command"]
@@ -379,26 +381,50 @@ class FileSyncServer(RemoteFileServer):
         elif command == "update_file":
             return self.handle_update_file(message)
 
+    @contextmanager
+    def file_access_lock(self, path):
+        path = os.path.abspath(os.path.expanduser(path))
+
+        # even though messages arrive in sequence, there are edge cases:
+        # - change_file message comes before handle_open_file finishes.
+        # - utils.get_buffer_content utils.get_file_content_from_file_server
+        #   try to read file content before handle_open_file finishes.
+        #
+        # Add a threading.Lock() for each file operation to ensure atomic access.
+        lock = self.file_locks.setdefault(path, threading.Lock())
+        try:
+            lock.acquire()
+            yield
+        finally:
+            lock.release()
+
+    def get_file_content(self, path):
+        with self.file_access_lock(path):
+            return self.file_dict.get(path, "")
+
     def handle_update_file(self, message):
-        path = os.path.expanduser(message["path"])
-        self.file_dict[path] = message["content"]
+        path = message["path"]
+        with self.file_access_lock(path):
+            self.file_dict[path] = message["content"]
 
     def handle_remote_sync(self, message):
         remote_info = message["remote_connection_info"]
         set_remote_connection_info(remote_info)
 
     def handle_open_file(self, message):
-        path = os.path.expanduser(message["path"])
+        path = message["path"]
         response = {**message, "path": path}
 
         if os.path.exists(path):
-            with open(path) as f:
-                content = f.read()
-                response.update({
-                    "path": path,
-                    "content": content
-                })
-                self.file_dict[path] = content
+            with self.file_access_lock(path):
+                with open(path) as f:
+                    content = f.read()
+                    response.update({
+                        "path": path,
+                        "content": content
+                    })
+                    self.file_dict[path] = content
+                    print("file_dict after handle_open_file: " + str(self.file_dict.keys()))
         else:
             response.update({
                 "path": path,
@@ -410,24 +436,28 @@ class FileSyncServer(RemoteFileServer):
 
     def handle_change_file(self, message):
         path = message["path"]
-        if path not in self.file_dict:
-            with open(path) as f:
-                self.file_dict[path] = f.read()
 
-        self.file_dict[path] = rebuild_content_from_diff(self.file_dict[path], message["args"][0], message["args"][1], message["args"][3])
+        with self.file_access_lock(path):
+            if path not in self.file_dict:
+                with open(path) as f:
+                    self.file_dict[path] = f.read()
+
+            self.file_dict[path] = rebuild_content_from_diff(self.file_dict[path], message["args"][0], message["args"][1], message["args"][3])
 
     def handle_save_file(self, message):
         path = message["path"]
 
         if path in self.file_dict:
-            with open(path, 'w') as file:
-                file.write(self.file_dict[path])
+            with self.file_access_lock(path):
+                with open(path, 'w') as file:
+                    file.write(self.file_dict[path])
 
     def handle_close_file(self, message):
         path = message["path"]
 
         if path in self.file_dict:
-            del self.file_dict[path]
+            with self.file_access_lock(path):
+                del self.file_dict[path]
 
     def close_all_files(self):
         self.file_dict.clear()

--- a/core/utils.py
+++ b/core/utils.py
@@ -126,15 +126,15 @@ def get_buffer_content(filename, buffer_name):
     global lsp_bridge_server
 
     if lsp_bridge_server and lsp_bridge_server.file_server:
-        return lsp_bridge_server.file_server.file_dict[filename]
+        return lsp_bridge_server.file_server.get_file_content(filename)
     else:
         return get_emacs_func_result('get-buffer-content', buffer_name)
 
 def get_file_content_from_file_server(filename):
     global lsp_bridge_server
 
-    if lsp_bridge_server and lsp_bridge_server.file_server and filename in lsp_bridge_server.file_server.file_dict:
-        return lsp_bridge_server.file_server.file_dict[filename]
+    if lsp_bridge_server and lsp_bridge_server.file_server:
+        return lsp_bridge_server.file_server.get_file_content(filename)
     else:
         return ""
 

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -2987,10 +2987,7 @@ SSH tramp file name is like /ssh:user@host#port:path"
       (set-visited-file-name tramp-filename t t)
       ;; auto reload the file content if formatter made change
       ;; otherwise when saving file emacs will warn file has been changed on disk
-      (auto-revert-mode 1)
-
-
-      ))
+      (auto-revert-mode 1)))
 
   (when lsp-bridge-ref-open-remote-file-go-back-to-ref-window
     (lsp-bridge-switch-to-ref-window)

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1822,24 +1822,9 @@ So we build this macro to restore postion after code format."
 (defun lsp-bridge-completion-ui-visible-p ()
   (acm-frame-visible-p acm-menu-frame))
 
-(defun lsp-bridge-update-tramp-docker-file-mod-time ()
-  "Updaet buffer visited file mode time."
-  ;; set-visited-file-name associate a buffer with a file path.
-  ;; file timestamps are handled or recognized by Emacs through TRAMP.
-  ;; discrepancies of file timestamps will make Emacs warn about file has been
-  ;; changed since visited or saved.
-  (when (string-prefix-p "/docker:" buffer-file-name)
-    (let* ((file-name (lsp-bridge-get-buffer-file-name-text))
-           (tramp-vec (tramp-dissect-file-name file-name))
-           (path (tramp-file-name-localname tramp-vec))
-           (host (tramp-file-name-host tramp-vec)))
-      (lsp-bridge--conditional-update-tramp-file-info file-name path host
-                                                      (set-visited-file-modtime
-                                                       (file-attribute-modification-time (file-attributes buffer-file-name)))))))
 
 (defun lsp-bridge-monitor-after-save ()
-  (lsp-bridge-call-file-api "save_file" (buffer-name))
-  (lsp-bridge-update-tramp-docker-file-mod-time))
+  (lsp-bridge-call-file-api "save_file" (buffer-name)))
 
 (defcustom lsp-bridge-find-def-fallback-function nil
   "Fallback for find definition failure."
@@ -3002,7 +2987,10 @@ SSH tramp file name is like /ssh:user@host#port:path"
       (set-visited-file-name tramp-filename t t)
       ;; auto reload the file content if formatter made change
       ;; otherwise when saving file emacs will warn file has been changed on disk
-      (auto-revert-mode 1)))
+      (auto-revert-mode 1)
+
+
+      ))
 
   (when lsp-bridge-ref-open-remote-file-go-back-to-ref-window
     (lsp-bridge-switch-to-ref-window)


### PR DESCRIPTION
- remove lsp-bridge-update-tramp-docker-file-mod-time, it is not usefull
- update readme with a tested example
- update readme of how to work with apheleia to auto-format remote docker file