### PR TITLE
Fixup getting project path on Windows

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -362,7 +362,13 @@ def get_project_path(filepath):
         import os
         dir_path = os.path.dirname(filepath)
         if get_command_result("git rev-parse --is-inside-work-tree", dir_path) == "true":
-            return get_command_result("git rev-parse --show-toplevel", dir_path)
+            path_from_git = get_command_result("git rev-parse --show-toplevel", dir_path)
+            if get_os_name() == "windows":
+                path_parts = path_from_git.split("/")
+                windows_path = path_parts[1] + ":/" + "/".join(path_parts[2:])
+                return windows_path
+            else:
+                return path_from_git
         else:
             return filepath
 


### PR DESCRIPTION
Sometimes ‘git rev-parse —show-toplevel’ is used in core/utils.py to get project path for an existing source file. That git subcommand would convert a Windows style path like “f:/foo/bar.py” to “/f/foo” and cause unexpected behavior on Windows OS’s.

I’ve made a possible fix to that git behavior. Thank you for reviewing this patch.