### PR TITLE
Remove set-visited-file-name for remote docker file

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,13 +176,13 @@ If you use `apheleia` as formatter, `lsp-bridge` now support auto formatting fil
 ```elsip
 (use-package! apheleia
   :config
-  (setq +format-with-lsp nil)
   ;; which formatter to use
   (setf (alist-get 'python-mode apheleia-mode-alist) 'ruff)
   (setf (alist-get 'python-ts-mode apheleia-mode-alist) 'ruff)
-
-  (setq apheleia-remote-algorithm 'local)
-  (setq apheleia-post-format-hook #'lsp-bridge-monitor-after-save))
+  ;; don't mess up with lsp-mode
+  (setq +format-with-lsp nil)
+  ;; run the formatter inside container
+  (setq apheleia-remote-algorithm 'remote))
 ```
 
 ## Keymap

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -174,13 +174,13 @@ lsp-bridge 开箱即用， 安装好语言对应的 [LSP 服务器](https://gith
 ```elisp
 (use-package! apheleia
   :config
-  (setq +format-with-lsp nil)
   ;; which formatter to use
   (setf (alist-get 'python-mode apheleia-mode-alist) 'ruff)
   (setf (alist-get 'python-ts-mode apheleia-mode-alist) 'ruff)
-
-  (setq apheleia-remote-algorithm 'local)
-  (setq apheleia-post-format-hook #'lsp-bridge-monitor-after-save))
+  ;; don't mess up with lsp-mode
+  (setq +format-with-lsp nil)
+  ;; run the formatter inside container
+  (setq apheleia-remote-algorithm 'remote))
 ```
 
 ## 按键

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1852,7 +1852,6 @@ So we build this macro to restore postion after code format."
 (defun lsp-bridge-completion-ui-visible-p ()
   (acm-frame-visible-p acm-menu-frame))
 
-
 (defun lsp-bridge-monitor-after-save ()
   (lsp-bridge-call-file-api "save_file" (buffer-name)))
 
@@ -3011,13 +3010,7 @@ SSH tramp file name is like /ssh:user@host#port:path"
                                                                 lsp-bridge-remote-file-port
                                                                 lsp-bridge-remote-file-path)))
       ;; use `find-file' to open TRAMP docker file will open a tramp buffer, kill it
-      (kill-buffer (get-file-buffer tramp-filename))
-      ;; set the name of the file visited in the current buffer
-      ;; the next time the buffer is saved it will go in the tramp file
-      (set-visited-file-name tramp-filename t t)
-      ;; auto reload the file content if formatter made change
-      ;; otherwise when saving file emacs will warn file has been changed on disk
-      (auto-revert-mode 1)))
+      (kill-buffer (get-file-buffer tramp-filename))))
 
   (when lsp-bridge-ref-open-remote-file-go-back-to-ref-window
     (lsp-bridge-switch-to-ref-window)


### PR DESCRIPTION
Remove it will make things just work, keeping buffer as a non-file buffer
- aphelia formatter will work with remote file
- use `set-visited-file-name` will result in saving the file twice, and we have to deal with buffer `modtime`, and unsaved change.
- keep the same logic as remote SSH file

Update README about how to use formatter with remote file. 