### PR TITLE
Support lsp-bridge in container correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,13 @@ start the devcontainer and use `file-find` `/docker:user@container:/path/to/file
 more detail please refer to [devcontainer-feature-emacs-lsp-bridge](https://github.com/nohzafk/devcontainer-feature-emacs-lsp-bridge).
 
 If you use `apheleia` as formatter, `lsp-bridge` now support auto formatting file on devcontainer.
+```elisp
+;; setup PATH for remote command execution
+(with-eval-after-load 'tramp
+  (add-to-list 'tramp-remote-path "~/.nix-profile/bin")
+  (add-to-list 'tramp-remote-path 'tramp-own-remote-path))
 
-```elsip
-(use-package! apheleia
+(use-package apheleia
   :config
   ;; which formatter to use
   (setf (alist-get 'python-mode apheleia-mode-alist) 'ruff)

--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -553,7 +553,7 @@ def get_container_local_ip(container_name):
         result = subprocess.check_output(command, shell=True, text=True).strip()
         return result
     except subprocess.CalledProcessError:
-        message_emacs(f"{traceback.format_exc()}")
+        message_emacs(f"get_container_local_ip error: {traceback.format_exc()}")
         return None
 
 

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -197,9 +197,8 @@ class LspBridge:
 
     @threaded
     def init_remote_file_server(self):
-        print("* Running lsp-bridge in remote server, "
-              "use command 'lsp-bridge-open-remote-file' to open remote file, "
-              "or 'find-file' /docker: to open file in running container.")
+        print("* Running lsp-bridge on remote server. "
+              "Access files with 'lsp-bridge-open-remote-file' or 'find-file /docker:...'")
 
         # Build loop for remote files management.
         self.file_server = FileSyncServer("0.0.0.0", REMOTE_FILE_SYNC_CHANNEL)
@@ -437,6 +436,7 @@ class LspBridge:
                 self.remote_sync(container_name, tramp_connection_info)
                 # container_name is used for emacs buffer local variable lsp-bridge-remote-file-host
                 eval_in_emacs("lsp-bridge-update-tramp-file-info", tramp_file_name, tramp_connection_info, tramp_method, container_user, container_name, path)
+                eval_in_emacs("lsp-bridge--setup-tramp-docker-buffer", tramp_file_name)
                 self.sync_tramp_remote_complete_event.set()
             except Exception as e:
                 logger.exception(e)
@@ -510,7 +510,7 @@ class LspBridge:
                         "jump_define_pos": epc_arg_transformer(jump_define_pos)
                 })
         else:
-            message_emacs("Please input valid path match rule: 'ip:/path/file'.")
+            message_emacs(f"Unsupported remote path {path}")
 
     @threaded
     def update_remote_file(self, remote_file_host, remote_file_path, content):


### PR DESCRIPTION
# Unify the logic for remote SSH file and docker file

When using `find-file` to open a file in container, the TRAMP buffer is now setup as the **lsp-bridge buffer**

- we treat the TRAMP buffer as a non-file buffer by setting `buffer-file-name` to nil
- previous impl is not correct (create a new buffer for docker file and close the corresponding TRAMP buffer)
 
# Support apheleia formatter in container
Update README for how to setup PATH for remote command execution, otherwise the formatter binary won't be found (for example `ruff`, even it is installed in container)

# Support find defition in container 

Support using `lsp-bridge-find-def` `lsp-bridge-find-def-return`  `lsp-bridge-find-def-other-window`  in container.

Text Matrix

| lsp-bridge-find-def-select-in-open-windows | docker file | lsp-bridge-find-def/-return                                                                | lsp-bridge-find-def-other-window |
| ------------------------------------------ | ----------- | ------------------------------------------------------------------------------------------ | -------------------------------- |
| nil                                        | yes         | pass - jump to another file and jump back<br>pass - jump to current file and jump back<br> | pass - open a new window         |
| nil                                        | no          | pass - jump to another file and jump back<br>pass - jump to current file and jump back<br> | pass - open a new window         |
| t                                          | yes         | jump to opened window - pass                                                               | pass - jump to opened window     |
| t                                          | no          | jump to opened window - pass                                                               | pass - jump to opened window     |


## issue
Under current implementation if jump to other window,` lsp-bridge-find-def-return` can't jump back to original window. It would be nice if we support jump back to original window.



