### PR TITLE
Add support for SLY completion backend for Common Lisp.

### DIFF
--- a/acm/acm-backend-sly.el
+++ b/acm/acm-backend-sly.el
@@ -1,0 +1,71 @@
+;;; acm-backend-sly.el --- SLY completion backend -*- lexical-binding: t; -*-
+
+(require 'sly)
+
+(defcustom acm-enable-sly nil
+  "Enable SLY support for Lisp. "
+  :type 'boolean
+  :group 'acm-backend-sly)
+
+(defcustom acm-backend-sly-mode-list
+  '(
+    lisp-mode
+    sly-mrepl-mode
+    )
+  "The mode list to support SLY. "
+  :type 'cons)
+
+;; from https://github.com/joaotavora/sly/blob/ba40c8f054ec3b7040a6c36a1ef3e9596b936421/lib/sly-completion.el#L323C9-L335C36
+;; and see `acm-icon-alist' for the icon mapping
+;; from https://github.com/manateelazycat/lsp-bridge/blob/49b5497243873b1bddea09a4a988e3573ed7cc3e/acm/acm-icon.el#L94
+
+(defun acm-backend-sly-candidate-type (candidate)
+  (pcase (get-text-property 0 'sly--classification candidate)
+    ("fn"             "function")
+    ("generic-fn"     "method")
+    ("generic-fn,cla" "method")
+    ("cla,type"       "class")
+    ("cla"            "class")
+    ("special-op"     "operator")
+    ("type"           "class")
+    ("constant"       "constant")
+    ("var"            "variable")
+    ("pak"            "package")
+    ("pak,constant"   "package")
+    ("macro"          "macro")
+    (_                "unknown")))
+
+(defun acm-backend-sly-candidates (keyword)
+  (when (and (member major-mode acm-backend-sly-mode-list)
+	     (sly-connected-p))
+    (mapcar (lambda (candidate)
+	      (let* ((type (acm-backend-sly-candidate-type candidate))
+		     (note (get-text-property
+			    0 'sly--classification candidate)))
+		(list :key          candidate
+		      :icon         type
+		      :label        candidate
+		      :displayLabel candidate
+		      :annotation   note
+		      :backend      "sly")))
+	    (ignore-errors
+	      ;; see `sly-complete-symbol-function'
+	      ;; it will return (COMPLETIONS NIL),
+	      ;; where COMPLETIONS are a list of propertized strings
+	      (car (funcall sly-complete-symbol-function keyword))))))
+
+(defun acm-backend-sly-candidate-doc (candidate)
+  (when (sly-connected-p)
+    (let ((type (plist-get candidate :icon))
+	  (key  (plist-get candidate :key)))
+      ;; Note:
+      ;; here assumes that all the completion is
+      ;; within lisp namespace (no symbol existance check)
+      (pcase type
+	((or "function" "method" "operator")
+	 (sly-eval `(slynk:describe-function ,key)))
+	(_ (sly-eval `(slynk:describe-symbol ,key)))))))
+
+(provide 'acm-backend-sly)
+
+;;; acm-backend-sly.el ends here

--- a/acm/acm.el
+++ b/acm/acm.el
@@ -109,6 +109,7 @@
 (require 'acm-backend-jupyter)
 (require 'acm-backend-capf)
 (require 'acm-quick-access)
+(require 'acm-backend-sly)
 
 ;;; Code:
 
@@ -196,6 +197,7 @@
 
 (defcustom acm-completion-mode-candidates-merge-order '("elisp-candidates"
                                                         "lsp-candidates"
+							"sly-candidates"
                                                         "capf-candidates"
                                                         "jupyter-candidates"
                                                         "ctags-candidates"
@@ -467,6 +469,7 @@ Only calculate template candidate when type last character."
          (mode-candidates-min-index 2)
          (template-candidates-min-index 2)
          lsp-candidates
+	 sly-candidates
          capf-candidates
          path-candidates
          yas-candidates
@@ -503,6 +506,9 @@ Only calculate template candidate when type last character."
     (when acm-enable-capf
       (setq capf-candidates (acm-backend-capf-candiates keyword)))
 
+    (when acm-enable-sly
+      (setq sly-candidates (acm-backend-sly-candidates keyword)))
+
     (if acm-enable-search-sdcv-words
         ;; Completion SDCV if option `acm-enable-search-sdcv-words' is enable.
         (setq candidates (acm-backend-search-sdcv-words-candidates keyword))
@@ -524,6 +530,7 @@ Only calculate template candidate when type last character."
                                           ("elisp-candidates" (unless (acm-in-comment-p) (acm-backend-elisp-candidates keyword)))
                                           ("lsp-candidates" lsp-candidates)
                                           ("capf-candidates" capf-candidates)
+					  ("sly-candidates" sly-candidates)
                                           ("jupyter-candidates" jupyter-candidates)
                                           ("ctags-candidates" ctags-candidates)
                                           ("citre-candidates" citre-candidates)


### PR DESCRIPTION
The SLY backend was referring the CAPF backend.
To enable it:

1. set `acm-enable-sly' to be true;
2. at least one sly connection is existing `sly-connected-p';
3. major mode is within `acm-backend-sly-mode-list'.

The SLY classification id will be mapped to acm icon by `acm-backend-sly-candidate-type' function.

For the `acm-backend-sly-candidates', see
`sly-complete-symbol-function' for details.

Currently no existing symbol check for
`acm-backend-sly-candidate-doc', possibly, there maybe hidden bugs. (not triggered yet)

The `acm-backend-sly' need sly to be installed (requirable).