### PR TITLE
acm-backend-capf adapt sly, add annotation.

### DIFF
--- a/acm/acm-backend-capf.el
+++ b/acm/acm-backend-capf.el
@@ -125,25 +125,30 @@
 (defun acm-backend-capf-candiates (keyword)
   (when (member major-mode acm-backend-capf-mode-list)
     (let ((res (run-hook-wrapped 'completion-at-point-functions
-                                 #'completion--capf-wrapper 'all)))
+                                 #'completion--capf-wrapper 'all))
+          annotation-function)
       (mapcar (lambda (candidate)
                 (list :key candidate
                       :icon "capf"
                       :label candidate
                       :displayLabel candidate
-                      :annotation "CAPF"
+                      :annotation (if annotation-function
+                                      (concat (funcall annotation-function candidate) " CAPF")
+                                    "CAPF")
                       :backend "capf"))
               (pcase res
                 (`(,_ . ,(and (pred functionp) f)) (funcall f))
                 (`(,hookfun . (,start ,end ,collection . ,plist))
                  (unless (markerp start) (setq start (copy-marker start)))
+                 (setq annotation-function (plist-get plist :annotation-function))
                  (let* ((completion-extra-properties plist)
                         (completion-in-region-mode-predicate
                          (lambda ()
                            ;; We're still in the same completion field.
                            (let ((newstart (car-safe (funcall hookfun))))
-                             (and newstart (= newstart start))))))
-                   collection
+                             (and newstart (= newstart start)))))
+                        (initial (buffer-substring-no-properties start end)))
+                   (completion-all-completions initial collection nil (length initial))
                    )))))))
 
 (provide 'acm-backend-capf)

--- a/acm/acm-backend-capf.el
+++ b/acm/acm-backend-capf.el
@@ -147,9 +147,11 @@
                            ;; We're still in the same completion field.
                            (let ((newstart (car-safe (funcall hookfun))))
                              (and newstart (= newstart start)))))
-                        (initial (buffer-substring-no-properties start end)))
-                   (completion-all-completions initial collection nil (length initial))
-                   )))))))
+                        (initial (buffer-substring-no-properties start end))
+                        (candidates (completion-all-completions initial collection nil (length initial))))
+                   (when-let ((z (last candidates)))
+                     (setcdr z nil))
+                   candidates)))))))
 
 (provide 'acm-backend-capf)
 


### PR DESCRIPTION
适配了一下 sly，并且添加了 annotation，效果如下

![image](https://github.com/user-attachments/assets/2a473b80-7165-4887-80c1-7cf64590810b)
