### PR TITLE
fix when dir-local-find-file return string first time

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -981,7 +981,10 @@ So we build this macro to restore postion after code format."
       ;; Fetch project root path by `lsp-bridge-get-project-path-by-filepath' if it set by user.
       (funcall lsp-bridge-get-project-path-by-filepath filename)
     ;; Otherwise try to search up `.dir-locals.el' file
-    (car (dir-locals-find-file filename))))
+    (let ((result (dir-locals-find-file filename)))
+      (if (consp result)
+          (car result)
+        result))))
 
 (defun lsp-bridge--get-language-id-func (project-path file-path server-name extension-name)
   (if lsp-bridge-get-language-id


### PR DESCRIPTION
When searching .dir-locals.el first time in a project (not in dir-locals-directory-cache), dir-local-find-file will return string instead of a list