### PR TITLE
make lsp-bridge-diagnostic-hide-severities to works for list

### DIFF
--- a/core/fileaction.py
+++ b/core/fileaction.py
@@ -283,11 +283,13 @@ class FileAction:
     def get_diagnostics_count(self):
         return sum(len(diags) for diags in self.diagnostics.values())
 
-    def get_diagnostics(self):
+    def get_diagnostics(self, hide_severities=None):
         diagnostics = []
         diagnostic_count = 0
         for server_name in self.diagnostics:
             for diagnostic in self.diagnostics[server_name]:
+                if hide_severities and diagnostic["severity"] in hide_severities:
+                    continue
                 diagnostic["server-name"] = server_name
                 diagnostics.append(diagnostic)
 
@@ -298,7 +300,7 @@ class FileAction:
 
         return diagnostics
 
-    def list_diagnostics(self):
+    def list_diagnostics(self, hide_severities):
         diagnostic_count = 0
         for server_name in self.diagnostics:
             diagnostic_count += len(self.diagnostics[server_name])
@@ -306,7 +308,7 @@ class FileAction:
         if diagnostic_count == 0:
             message_emacs("No diagnostics found.")
         else:
-            eval_in_emacs("lsp-bridge-diagnostic--list", self.get_diagnostics())
+            eval_in_emacs("lsp-bridge-diagnostic--list", self.get_diagnostics(hide_severities))
 
     def sort_diagnostic(self, diagnostic_a, diagnostic_b):
         score_a = [diagnostic_a["range"]["start"]["line"],

--- a/lsp-bridge-diagnostic.el
+++ b/lsp-bridge-diagnostic.el
@@ -347,7 +347,7 @@ You can set this value with `(2 3 4) if you just need render error diagnostic."
 
 (defun lsp-bridge-diagnostic-list ()
   (interactive)
-  (lsp-bridge-call-file-api "list_diagnostics"))
+  (lsp-bridge-call-file-api "list_diagnostics" lsp-bridge-diagnostic-hide-severities))
 
 (defun lsp-bridge-diagnostic--list (diagnostics)
   (let ((filepath acm-backend-lsp-filepath)


### PR DESCRIPTION
Pass to python side and filter on python side.
This enables something like this to dynamically suppress some diagnostic.

```emacs-lisp
(defun leo/lsp-bridge-diagnostic-list-all ()
  (interactive)
  (let ((lsp-bridge-diagnostic-hide-severities '()))
    (lsp-bridge-diagnostic-list)))
```