### PR TITLE
setting cwd when launching lsp server

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -299,11 +299,15 @@ class LspServer:
         self.save_include_text = False
 
         # Start LSP server.
+        cwd = self.project_path
+        if os.path.isfile(self.project_path): # single file
+            cwd = os.path.dirname(self.project_path)
         self.lsp_subprocess = subprocess.Popen(self.server_info["command"],
                                                bufsize=DEFAULT_BUFFER_SIZE,
                                                stdin=PIPE,
                                                stdout=PIPE,
-                                               stderr=stderr)
+                                               stderr=stderr,
+                                               cwd=cwd)
 
         # Two separate thread (read/write) to communicate with LSP server.
         self.receiver = LspServerReceiver(self.lsp_subprocess, self.server_info["name"])


### PR DESCRIPTION
Some toolchains like rust-analyzer set up by rustup will look rust-toolchain.toml to decide which version to run. 
When there are multiple rust-toolchain.toml across subprojects/dependencies, it's important to sett cwd to the root project path.