### PR TITLE
only re-insert doc when doc change

### DIFF
--- a/acm/acm.el
+++ b/acm/acm.el
@@ -975,8 +975,9 @@ The key of candidate will change between two LSP results."
             ;; Insert documentation and turn on wrap line.
             (with-current-buffer (get-buffer-create acm-doc-buffer)
               (read-only-mode -1)
-              (erase-buffer)
-              (insert doc)
+              (when (not (string-equal doc acm-markdown-render-doc))
+                (erase-buffer)
+                (insert doc))
               (visual-line-mode 1))
 
             ;; Only render markdown styling when idle 200ms, because markdown render is expensive.


### PR DESCRIPTION
Otherwise, the doc will not be rendered in markdown like the attached gif because of this check.
https://github.com/manateelazycat/lsp-bridge/blob/db75a301714ca203798439bd087897c34dab0f8d/acm/acm.el#L1245
![acm-doc-markdown-render-bug](https://github.com/user-attachments/assets/d4fcebe7-0bf1-4148-80df-fbeab96e1000)
