### PR TITLE
fix expand rust macro

### DIFF
--- a/core/handler/rust_expand_macro.py
+++ b/core/handler/rust_expand_macro.py
@@ -12,4 +12,11 @@ class RustExpandMacro(Handler):
         return dict(position=position)
 
     def process_response(self, response: Union[dict, list]) -> None:
-        eval_in_emacs("lsp-bridge-rust-expand-macro--update", response["name"], response["expansion"])
+        if response is None:
+            print("Error: Received None response from rust-analyzer")
+            return
+
+        if "name" in response and "expansion" in response:
+            eval_in_emacs("lsp-bridge-rust-expand-macro--update", response["name"], response["expansion"])
+        else:
+            print(f"Error: Response missing 'name' or 'expansion' keys. Response: {response}")


### PR DESCRIPTION
when using `lsp-bridge-rust-expand-macro` command
error msg
```
Error when processing response 4247
Traceback (most recent call last):
  File "/Users/a/.emacs.d/var/straight/repos/lsp-bridge/core/handler/__init__.py", line 38, in handle_response
    self.process_response(response)
  File "/Users/a/.emacs.d/var/straight/repos/lsp-bridge/core/handler/rust_expand_macro.py", line 15, in process_response
    eval_in_emacs("lsp-bridge-rust-expand-macro--update", response["name"], response["expansion"])
TypeError: 'NoneType' object is not subscriptable
```