### PR TITLE
send formatting in capabilities and setup vscode-json-language-server

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -422,7 +422,16 @@ class LspServer:
                         "plaintext"
                     ],
                     "dynamicRegistration": True
-                }
+                },
+                "formatting": {
+                    "dynamicRegistration": True
+                },
+                "rangeFormatting": {
+                    "dynamicRegistration": True
+                },
+                "onTypeFormatting": {
+                    "dynamicRegistration": True
+                },
             },
             "window": {
                 "workDoneProgress": True

--- a/langserver/vscode-json-language-server.json
+++ b/langserver/vscode-json-language-server.json
@@ -5,5 +5,8 @@
     "vscode-json-language-server",
     "--stdio"
   ],
-  "settings": {}
+  "settings": {},
+  "initializationOptions": {
+    "provideFormatter": true
+  }
 }


### PR DESCRIPTION
vscode-json-language-server needs initiailizationOptions.provideFormatter to have documentFormattingProvider retunred by server.

ref: https://github.com/microsoft/vscode/blob/main/extensions/json-language-features/server/README.md#initialization-options