### PR TITLE
Feat add tabbyml support

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ lsp-bridge provides support for more than two language servers for many language
 - `acm-doc-frame-max-lines`: Max line number of help documentation, default is 20
 - `acm-candidate-match-function`: lsp-bridge frontend filter algorithm for candidates, options include `'regexp-quote`, `'orderless-flex`, `'orderless-literal`, `'orderless-prefixes`, `'orderless-regexp`, `'orderless-initialism`, default is `regexp-quote`, orderless-* started algorithms require additional installation of [orderless](https://github.com/oantolin/orderless)
 - `acm-completion-backend-merge-order`: Customize the order of the completion backends, default order is: first part of mode candidate, first part of template candidates, tabnine/copilot/codeium, second part of template candidates, second part of mode candidates, set `acm-completion-mode-candidates-merge-order` customize mode candidates order 
-- `acm-completion-mode-candidates-merge-order`: Customize the order of the mode candidates, the display order for mode candidates, default order: Elisp、 LSP、 Jupyter、 Ctags、 Citre、 ROAM、 Word、 Telegra
+- `acm-completion-mode-candidates-merge-order`: Customize the order of the mode candidates, the display order for mode candidates, default order: Elisp、 LSP、 Jupyter、 Tabby Ctags、 Citre、 ROAM、 Word、 Telegra
 - `acm-backend-lsp-candidate-min-length`: The minimum characters to trigger lsp completion, default is 0
 - `acm-backend-lsp-block-kind-list`: Filters certain types of LSP completion candidates. By default, it's a empty list. When the value is set to `'(Snippet Enum)`, this means that Snippet and Enum completions will not be shown.
 - `acm-backend-elisp-candidate-min-length`: The minimum characters to trigger elisp completion, default is 0

--- a/acm/acm-backend-tabby.el
+++ b/acm/acm-backend-tabby.el
@@ -1,0 +1,93 @@
+;;; acm-backend-tabby.el --- acm tabby support -*- lexical-binding: t; no-byte-compile: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+(defgroup acm-backend-tabby nil
+  "ACM tabby support."
+  :group 'acm)
+
+(defcustom acm-enable-tabby nil
+  "Enable tabby support."
+  :type 'boolean
+  :group 'acm-backend-tabby)
+
+(defvar-local acm-backend-tabby-items nil)
+
+(defun acm-backend-tabby-candidates (keyword)
+  (acm-with-cache-candidates
+   acm-backend-tabby-cache-candiates
+   (acm-candidate-sort-by-prefix
+    keyword
+    acm-backend-tabby-items)))
+
+
+(defun acm-backend-tabby-find-max-common (str1 str2)
+  "Find max common overlap between end of str1 and start of str2."
+  (let* ((max-count (min (length str1) (length str2)))
+         (overlap-size
+          (catch 'found
+            (dotimes (i max-count)
+              (let ((size (- max-count i)))
+                (when (string= (substring str1 (- (length str1) size))
+                               (substring str2 0 size))
+                  (throw 'found size))))
+            0)))
+    (if (and (> overlap-size 0)
+             (string= (substring str1 (- (length str1) overlap-size))
+                      (substring str2 0 overlap-size)))
+        (concat str1 (substring str2 overlap-size))
+      nil)))
+
+
+(defun acm-backend-tabby--get-candidates (&optional current-symbol is-manual)
+  "Do completion. IS-MANUAL is non-nil if the completion is triggered manually."
+  (interactive)
+  (when (string= tabby--status "initialization_done")
+    (if (not (zerop tabby--ongoing-request-id))
+        (tabby--agent-cancel-request tabby--ongoing-request-id)
+      (let* ((request (tabby--get-completion-context is-manual))
+             (before-request-pos (point))
+             (before-request-symbol (thing-at-point 'symbol t))
+             (on-response `(lambda (response)
+                             (let* ((choices (plist-get (cadr response) :choices))
+                                    (candidates (mapcar (lambda (choice) (plist-get choice :text))
+                                                        choices))
+                                    (candidates (if (stringp ,current-symbol)
+                                                    (mapcar (lambda (choice) (if (acm-backend-tabby-find-max-common ,before-request-symbol choice)
+                                                                                 (acm-backend-tabby-find-max-common ,before-request-symbol choice)
+                                                                               choice)) candidates)
+                                                  candidates))
+
+                                    (candidates (seq-filter #'stringp candidates))
+
+                                    (candidates-with-metadata (mapcar (lambda (candidate)
+                                                                        (list :key candidate
+                                                                              :icon "tabby"
+                                                                              :label candidate
+                                                                              :displayLabel candidate
+                                                                              :annotation "tabby"
+                                                                              :backend "tabby"))
+                                                                      candidates)))
+                               (when candidates
+                                 (lsp-bridge-search-backend--record-items "tabby" candidates-with-metadata))
+                               ))))
+
+        (setq tabby--current-completion-request request)
+        (setq tabby--ongoing-request-id
+              (tabby--agent-provide-completions request on-response))))))
+
+(defun acm-backend-tabby-record (current-symbol)
+  (interactive)
+  (unless (fboundp 'tabby--agent-provide-completions)
+    (require 'tabby))
+  (setq-local acm-backend-tabby-items nil)
+  (acm-backend-tabby--get-candidates current-symbol nil))
+
+(defun acm-backend-tabby-clean ()
+  (setq-local acm-backend-tabby-items nil)
+  (setq-local acm-backend-tabby-cache-candiates nil))
+
+(provide 'acm-backend-tabby)
+;;; acm-backend-tabby.el ends here

--- a/acm/acm.el
+++ b/acm/acm.el
@@ -108,6 +108,7 @@
 (require 'acm-backend-copilot)
 (require 'acm-backend-org-roam)
 (require 'acm-backend-jupyter)
+(require 'acm-backend-tabby)
 (require 'acm-backend-capf)
 (require 'acm-quick-access)
 
@@ -200,6 +201,7 @@
                                                         "lsp-workspace-symbol-candidates"
                                                         "capf-candidates"
                                                         "jupyter-candidates"
+                                                        "tabby-candidates"
                                                         "ctags-candidates"
                                                         "citre-candidates"
                                                         "org-roam-candidates"
@@ -485,6 +487,7 @@ Only calculate template candidate when type last character."
          codeium-candidates
          copilot-candidates
          jupyter-candidates
+         tabby-candidates
          tempel-candidates
          mode-candidates
          mode-first-part-candidates
@@ -510,6 +513,9 @@ Only calculate template candidate when type last character."
 
     (when acm-enable-jupyter
       (setq jupyter-candidates (acm-backend-jupyter-candidates keyword)))
+
+    (when acm-enable-tabby
+      (setq tabby-candidates (acm-backend-tabby-candidates keyword)))
 
     (when acm-enable-capf
       (setq capf-candidates (acm-backend-capf-candiates keyword)))
@@ -548,6 +554,7 @@ Only calculate template candidate when type last character."
                                           ("lsp-workspace-symbol-candidates" lsp-workspace-symbol-candidates)
                                           ("capf-candidates" capf-candidates)
                                           ("jupyter-candidates" jupyter-candidates)
+                                          ("tabby-candidates" tabby-candidates)
                                           ("ctags-candidates" ctags-candidates)
                                           ("citre-candidates" citre-candidates)
                                           ("org-roam-candidates" org-roam-candidates)

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1793,6 +1793,11 @@ So we build this macro to restore postion after code format."
                (string-prefix-p "jupyter" (plist-get (car (cdr (org-element-context))) :language)))
       (acm-backend-jupyter-record current-symbol))
 
+    ;; tabby complete
+    (when (and acm-enable-tabby
+               (lsp-bridge-process-live-p))
+      (acm-backend-tabby-record current-symbol))
+
     (when (and acm-enable-ctags
                (lsp-bridge-process-live-p))
       (unless (or (string-equal current-word "") (null current-word))


### PR DESCRIPTION
1. add a tabbyml support by using [tabby.el](https://github.com/alan-w-255/tabby.el) as a client for sending request to tabby-agent
  Notice:  tabby.el provide a tabby-mode which is laggy which use overlay and post-command-hook when used together with lsp-bridge directly, So I write this backend for acm.el.
2. tabby completion result maybe too late for the users completion, so I add a function `acm-backend-tabby-find-max-common` to drop the common suffix for users input and the prefix of the tabby's completion, eg: to write a bubble sort function
   (1) the user type: `def bubb`
   (2) trigger tabby completion
   (3) the user contine typing: `def bubble_s`
   (4) the tabby completion finished: `le_sort(arr):`
   (5) merge the input and the completion:  `def bubble_sort(arr):`
   
3. **How to enable**: 
    (1) `acm-backend-tabby` set to t
    (2) deploy your tabbyml/tabby server, reference: [tabbyml/tabby](https://tabby.tabbyml.com/docs/welcome/)
    (3) install [tabby.el](https://github.com/alan-w-255/tabby.el)
    (4) on your computer which run emacs,  [setup tabby-agent's config](https://tabby.tabbyml.com/docs/extensions/configurations/)
    (5) You don't need to install a tabby-agent directly, as tabbly.el itself distributed with the tabby-agent's javascript codes.
    
4. preview:

![image](https://github.com/user-attachments/assets/f1e6af11-aadc-4bc3-b531-1cdd8d16681f)

 Maybe the tabby its own problem or I used a basic model deepseek-1.3B, the completion is Not a full function.
