### PR TITLE
fix some org babel issues

### DIFF
--- a/acm/acm-backend-capf.el
+++ b/acm/acm-backend-capf.el
@@ -114,7 +114,6 @@
                                         anaconda-mode
                                         redis-mode
                                         lisp-mode
-                                        org-mode
                                         )
   "The mode list to support capf."
   :type 'cons)
@@ -150,9 +149,18 @@
                            (let ((newstart (car-safe (funcall hookfun))))
                              (and newstart (= newstart start)))))
                         (initial (buffer-substring-no-properties start end))
-                        (candidates (completion-all-completions initial collection nil (length initial))))
+                        (candidates (completion-all-completions initial collection nil (length initial)))
+                        prefix)
                    (when-let ((z (last candidates)))
                      (setcdr z nil))
+                   ;; Sometime CAPF excludes the prefix from the candidates.
+                   ;; Adding it back based on the `keyword' and `initial'.
+                   (when (> (length keyword) (length initial))
+                     (setq prefix (substring keyword 0  (- (length keyword)
+                                                           (length initial))))
+                     (setq candidates (mapcar (lambda (candidate)
+                                                (concat prefix candidate))
+                                              candidates)))
                    candidates)))))))
 
 (provide 'acm-backend-capf)

--- a/acm/acm.el
+++ b/acm/acm.el
@@ -382,8 +382,7 @@ So we use `minor-mode-overriding-map-alist' to override key, make sure all keys 
 
 (defun acm-get-input-prefix-bound ()
   (cond
-   ((or (equal "string" acm-input-bound-style)
-        (derived-mode-p 'org-mode))
+   ((equal "string" acm-input-bound-style)
     (cons (point)
           (save-excursion
             (if (search-backward-regexp "\\s-" (point-at-bol) t)

--- a/core/fileaction.py
+++ b/core/fileaction.py
@@ -215,9 +215,15 @@ class FileAction:
             if isinstance(self.completion_block_kind_list, list):
                 self.completion_block_kind_list = list(map(lambda x: x.lower(), self.completion_block_kind_list))
 
-        delay = 0 if is_running_in_server() else 0.1
-        self.try_completion_timer = threading.Timer(delay, lambda : self.try_completion(position, before_char, prefix, self.version))
-        self.try_completion_timer.start()
+        if position['line'] < 0:
+            # TODO fix this from elisp happened in org source code completion
+            # We can temporary fix this by ignore this case,
+            # which will not influence the completion result.
+            logger.error("Invalid position change file", start, end, range_length, change_text, position, before_char, buffer_name, prefix, self.org_line_bias)
+        else:
+            delay = 0 if is_running_in_server() else 0.1
+            self.try_completion_timer = threading.Timer(delay, lambda : self.try_completion(position, before_char, prefix, self.version))
+            self.try_completion_timer.start()
 
     def update_file(self, buffer_name, org_line_bias=None):
         self.org_line_bias = org_line_bias

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1755,10 +1755,14 @@ So we build this macro to restore postion after code format."
             (lsp-bridge-complete-other-backends)
 
             ;; Update search words backend.
-            (lsp-bridge-search-words-update
-             lsp-bridge--before-change-begin-pos
-             lsp-bridge--before-change-end-pos
-             change-text)
+            ;;
+            ;; disable it for org-mode when we enable `lsp-bridge-enable-org-babel'
+            ;; it will trigger with wrong pos due to we only update `pos' on src block
+            (unless (eq major-mode 'org-mode)
+              (lsp-bridge-search-words-update
+               lsp-bridge--before-change-begin-pos
+               lsp-bridge--before-change-end-pos
+               change-text))
             ))))))
 
 (defun lsp-bridge-complete-other-backends ()


### PR DESCRIPTION
1. fix acm-get-input-prefix-bound for org-mode
2. fix mismatch in capf for org (capf for org is disabled by default)
3. skip negative line in change_file
4. disable search_words_update for org babel