### PR TITLE
Support "pipx run" command as lsp-bridge-python-command

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1232,6 +1232,8 @@ So we build this macro to restore postion after code format."
     ;; start epc server and set `lsp-bridge-server-port'
     (lsp-bridge--start-epc-server)
     (let* ((lsp-bridge-args (append
+                             (when (equal lsp-bridge-python-command "pipx")
+                               (list "run"))
                              (list lsp-bridge-python-file)
                              (list (number-to-string lsp-bridge-server-port))
                              (when lsp-bridge-enable-profile

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -1,6 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+# /// script
+# dependencies = [
+#   "epc",
+#   "orjson",
+#   "sexpdata",
+#   "six",
+#   "setuptools",
+#   "paramiko",
+#   "rapidfuzz",
+#   "watchdog",
+# ]
+# ///
+
 # Copyright (C) 2022 Andy Stewart
 #
 # Author:     Andy Stewart <lazycat.manatee@gmail.com>


### PR DESCRIPTION
## Motivation

In recent years, it has become very difficult to do a system-wide pip install as described in the README due to [PEP 668 – Marking Python base environments as “externally managed”](https://peps.python.org/pep-0668/).

## Solution

[`pipx run`](https://github.com/pypa/pipx?tab=readme-ov-file#walkthrough-running-an-application-in-a-temporary-virtual-environment) transparently creates a virtual environment and automatically resolves the latest dependencies.

`pipx` supports [PEP 723 – Inline script metadata](https://peps.python.org/pep-0723/), so packages embedded in `lsp_bridge.py` scripts will be automatically installed.

The tradeoff is that we have to wait a few seconds on startup for the dependency checks, which was not a pain for me since it only happens when the server starts.

To enable `pipx` to start servers, just set the following option:

```el
(setopt lsp-bridge-python-command "pipx")
```

What do you think about offering an opt-in feature like this?