### PR TITLE
lsp-bridge 找不到虚拟环境中安装的 lsp-server 命令 #1103

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1225,6 +1225,24 @@ So we build this macro to restore postion after code format."
   (interactive)
   (lsp-bridge-call-async "profile_dump"))
 
+(defun lsp-bridge--build-process-environment ()
+  "Create lsp-bridge subprocess process environments"
+  (let ((path (getenv "PATH"))
+        (pyvenv-bin-path (file-name-directory lsp-bridge-python-command))
+        (environments (seq-filter (lambda (env) (not (string-match-p "^PATH=" env)))
+                                  process-environment)))
+
+    ;; When `lsp-bridge-python-command' is the default value (ie: python[3.X]),
+    ;; use the original value of the environment variable `PATH',
+    ;; otherwise add the `pyvenv' bin directory to the head of the `PATH' environment variable.
+    (cl-pushnew (concat "PATH=" (cond ((not pyvenv-bin-path) path)
+                                      ((not (file-exists-p pyvenv-bin-path)) path)
+                                      ((string-match-p pyvenv-bin-path path) path)
+                                      (t (prog2
+                                             (message "[LSP-Bridge] Add '%s' to executable path." pyvenv-bin-path)
+                                             (string-join (list pyvenv-bin-path path) path-separator))))) environments)
+    environments))
+
 (defun lsp-bridge-start-process ()
   "Start LSP-Bridge process if it isn't started."
   (if (lsp-bridge-process-live-p)
@@ -1249,7 +1267,8 @@ So we build this macro to restore postion after code format."
         (setq lsp-bridge-internal-process-args lsp-bridge-args))
 
       ;; Start python process.
-      (let ((process-connection-type (not (lsp-bridge--called-from-wsl-on-windows-p))))
+      (let ((process-connection-type (not (lsp-bridge--called-from-wsl-on-windows-p)))
+            (process-environment (lsp-bridge--build-process-environment)))
         (setq lsp-bridge-internal-process
               (apply 'start-process
                      lsp-bridge-name lsp-bridge-name


### PR DESCRIPTION
### 问题详解:
单独为 lsp-bridge 创建一个 `python` 虚拟环境时（`lsp-bridge` 所有与`python`相关依赖都将安装这个环境中，如：`basedpyright`）。配置了`lsp-bridge-python-command` 值后，启动 `lsp-bridge` 时出现找不到语言服务器的命令的错误。

我觉得如果配置了 `lsp-bridge-python-command` ，那么其环境中安装的东西应该是 lsp-bridge 优先使用的，其次才查询系统环境的实现或者失败。

### 解决思路:
`python `虚拟环境未激活情况下，直接使用虚拟环境的`python`命令运行脚本时，其继承的是系统环境的`PATH`。所以当执行 `subprocess `和 `shutil.which `等代码时，其 `PATH` 未包含虚拟环境 `bin` 目录. 所以解决问题方法是将虚拟环境的 `bin` 目录直接添加 `PATH` 最前面。