### PR TITLE
Fix: lsp_bridge.py raises a `KeyError` when a code action is triggered in tramp.

### DIFF
--- a/core/handler/code_action.py
+++ b/core/handler/code_action.py
@@ -12,12 +12,12 @@ class CodeAction(Handler):
     def process_request(self, lsp_server_name, diagnostics, range_start, range_end, action_kind) -> dict:
         self.action_kind = action_kind
         self.lsp_server_name = lsp_server_name
-        
+
         range = {
             "start": range_start,
             "end": range_end
         }
-        
+
         if isinstance(action_kind, str):
             context = {
                 "diagnostics": diagnostics,
@@ -27,18 +27,12 @@ class CodeAction(Handler):
             context = {
                 "diagnostics": diagnostics
             }
-            
+
         return dict(range=range, context=context)
 
     def process_response(self, response) -> None:
         remote_connection_info = get_remote_connection_info()
-        if remote_connection_info != "" :
+        if remote_connection_info != "":
             for item in response:
-                changes = item["edit"]["changes"]
-                new_changes = {}
-                for file in changes.keys():
-                    tramp_file = local_path_to_tramp_path(file, remote_connection_info)
-                    new_changes[tramp_file] = changes[file]
-                item["edit"]["changes"] = new_changes
-
+                convert_workspace_edit_path_to_tramped_path(item["edit"], remote_connection_info)
         self.file_action.push_code_actions(response, self.lsp_server_name, self.action_kind)

--- a/core/handler/rename.py
+++ b/core/handler/rename.py
@@ -16,14 +16,7 @@ class Rename(Handler):
 
         remote_connection_info = get_remote_connection_info()
         logger.info(response)
-        if remote_connection_info != "" :
-            changes = response["changes"]
-            new_changes = {}
-            for file in changes.keys():
-                tramp_file = local_path_to_tramp_path(file, remote_connection_info)
-                new_changes[tramp_file] = changes[file]
-            response["changes"] = new_changes
-
+        convert_workspace_edit_path_to_tramped_path(response, remote_connection_info)
         eval_in_emacs("lsp-bridge-workspace-apply-edit", response)
-        
+
         message_emacs("Rename done.")


### PR DESCRIPTION
## Problem
When I triggered a code action in a file over the tramp, the lsp_bridge.py output the following error, and the code action did not work.

```
--- [19:54:05.515935] Recv textDocument/codeAction response (26129) from 'ruff' for project sandbox
Error when processing response 26129
Traceback (most recent call last):
  File "... /lsp-bridge/core/handler/__init__.py", line 38, in handle_response
    self.process_response(response)
  File "... /lsp-bridge/core/handler/code_action.py", line 37, in process_response
    changes = item["edit"]["changes"]
KeyError: 'changes'
```

## Fix
The `item["edit"]` is assumed to be a WorkspaceEdit instance and it looks to have one of (`changes ` or `documentChanges` ).
See:  https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceEdit

Since the current version only supports the `changes` case, I added an implementation to support `documentChanges` to fix the problem.

## Note
Although I have implemented cases for all documentChanges types (TextDocumentEdit, CreateFile, DeleteFile, RenameFile), I was only able to confirm the case of TextDocumentEdit that is returned in `code_action.py` and `rename.py`. I could not test the other types, CreateFile, DeleteFile, and RenameFile, because I am not sure in what use cases lsp would return these operations.


I would appreciate it if you could confirm this.