### PR TITLE
Include `packaging` in pipx dependencies

### DIFF
--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -5,6 +5,7 @@
 # dependencies = [
 #   "epc",
 #   "orjson",
+#   "packaging",
 #   "sexpdata",
 #   "six",
 #   "setuptools",


### PR DESCRIPTION
`packaging` is imported by core/tabnine.py. Let's include it in the pipx dependencies as well. Otherwise, `pipx run lsp_bridge.py` may complain with errors

```
Traceback (most recent call last):
  File "lsp_bridge.py", line 55, in <module>
    from core.tabnine import TabNine
  File "core/tabnine.py", line 31, in <module>
    from packaging.version import Version
ModuleNotFoundError: No module named 'packaging'
```