### PR TITLE
fix infinite-loop in `lsp-bridge-elisp-get-filepath` when yaml-mode

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1938,7 +1938,10 @@ The line number is relative to the beginning of the source block."
                                  (if (and (file-name-directory file-path) (file-exists-p (file-name-directory file-path)))
                                      (progn
                                        (throw 'break file-path))
-                                   (goto-char (1- file-beg))))
+                                   (if (eq file-beg 1)
+                                       ;; Reached beginning of buffer
+                                       (throw 'break nil)
+                                     (goto-char (1- file-beg)))))
                              (throw 'break nil))))))))
     filepath))
 


### PR DESCRIPTION
The `lsp-bridge-elisp-get-filepath` appears to enter infinite-loop when yaml-mode.

## How to reproduce the problem
1. setup a yaml lsp server (`npm install -g yaml-language-server`)
2. open a yaml file (`test.yaml`)
3. add some valid items (`a: 1`)
4. move the cursor to beginning-of-buffer
5. type any characters, see the example below.

ex.
```yaml
  <- type here in yaml model
a: 1
b: 2
c: 3
```

## About the fix

In the while loop of the `lsp-bridge-elisp-get-filepath`  function, if `file-beg` variable has `1` and the substring does not match any existing file paths,  the result of `(goto-char (1- file-beg))` would not change cursor position (`file-beg` is still `1`) and repeat the same loop infinitely.

I added a check to see whether the `file-beg` variable reaches the `beginning-of-buffer` or not.

I could not observe the problem in other language like python-mode.
The yaml seems to be special because a string without quotes (`"` or `'`) could be recognized as a valid string. In other languages, strings would be enclosed by quotes `"abc" or 'abc'`, which may avoid the variable `file-beg` reaches to `1`


I would appreciate it if you could review this PR.