### PR TITLE
fix: find last dot position to determine file extension

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1085,7 +1085,7 @@ So we build this macro to restore postion after code format."
 
 (defun lsp-bridge-get-lang-server-by-extension (filename extension-list)
   "Get lang server for file extension."
-  (when-let* ((dot-pos (cl-position ?. filename))
+  (when-let* ((dot-pos (cl-position ?. filename :from-end t))
               (file-extension (substring filename (1+ dot-pos) (length filename)))
               (langserver-info (cl-find-if
                                (lambda (pair)


### PR DESCRIPTION
if file name is `abc.spec.ts`, the detected extension is currently `spec.ts` while it should be `ts`