### PR TITLE
fix: Add missing self parameter to turn_off_by_single_file

### DIFF
--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -815,7 +815,7 @@ class LspBridge:
             message_emacs(message + ", disable LSP feature.")
             eval_in_emacs("lsp-bridge--turn-off-lsp-feature", filepath, get_lsp_file_host())
 
-    def turn_off_by_single_file(filepath, single_lang_server):
+    def turn_off_by_single_file(self, filepath, single_lang_server):
         self.turn_off(
             filepath,
             "ERROR: {} not support single-file, you need put this file in a git repository or put .dir-locals.el in project root directory".format(single_lang_server))


### PR DESCRIPTION
lsp_bridge.py中的turn_off_by_single_file函数缺失self参数，会导致报错。