### PR TITLE
fix: don't start copilot when not used

### DIFF
--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -679,7 +679,8 @@ class LspBridge:
         multi_lang_server = get_emacs_func_result("get-multi-lang-server", project_path, filepath)
 
         # notify change workspace folder to copilot server
-        self.copilot.change_workspace_folder(project_path)
+        if self.copilot.is_initialized:
+            self.copilot.change_workspace_folder(project_path)
 
         if os.path.splitext(filepath)[-1] == '.org':
             single_lang_server = get_emacs_func_result("get-single-lang-server", project_path, filepath)


### PR DESCRIPTION
#1188 introduced a change that unintentionally starts copilot, even if you don't use it. If you didn't have nodejs installed, this would break lsp-bridge.