### PR TITLE
acm-backend-copilot-show-trailing: mimic VSCode

### DIFF
--- a/acm/acm-backend-copilot.el
+++ b/acm/acm-backend-copilot.el
@@ -29,6 +29,10 @@
   :type 'string
   :group 'acm-backend-copilot)
 
+(defcustom acm-backend-copilot-show-trailing nil
+  "Show only the trailing parts for copilot. (like the VSCode)"
+  :group 'acm-backend-copilot)
+
 (defcustom acm-backend-copilot-accept nil
   "Send accept request."
   :type 'boolean
@@ -56,7 +60,26 @@ in the proxy plist. For example:
 (defun acm-backend-copilot-candidates (keyword)
   (acm-with-cache-candidates
    acm-backend-copilot-cache-candiates
-   acm-backend-copilot-items))
+   (if acm-backend-copilot-show-trailing
+       (acm-backend-copilot-candidates-preprocess acm-backend-copilot-items)
+     acm-backend-copilot-items)))
+
+(defun acm-backend-copilot-candidates-preprocess (copilot-candidates)
+  "Preprocess copilot candidates to show only trailing parts like VSCode Copilot."
+  (let* ((line-text (buffer-substring-no-properties (line-beginning-position) (point)))
+         (trimmed (string-trim-left line-text))
+         (prefix (if (string-match ".*\\s-+" trimmed)
+                     (match-string 0 trimmed)
+                   ""))
+         (prefix-len (length prefix)))
+    (mapcar (lambda (copilot-candidate)
+              (let* ((copilot-line (plist-get copilot-candidate :displayLabel))
+                     (trailing-text (if (string-prefix-p prefix copilot-line)
+                                        (substring copilot-line prefix-len)
+                                      copilot-line)))
+                (plist-put copilot-candidate :displayLabel trailing-text)
+                copilot-candidate))
+            copilot-candidates)))
 
 (defun acm-backend-copilot-candidate-expand (candidate-info bound-start &optional preview)
   ;; We need replace whole area with copilot label.


### PR DESCRIPTION
I finally just upgraded lsp-bridge to the latest version again yesterday lol.

The new integration of copilot-language-server with inlineCompletion will show the whole line as displayLabel, which is not the same as VSCode and the old version of lsp-bridge with copilot-node-server: which only show the trailing parts of the completions.

If the current line is ""a b cd" and copilot returns ""a b cde fg"; the displayLabel will be changed to "cde fg": keeps the current words and the trailings.

I don't know where to put the change; so just put it in the `acm.el` in the `acm-menu-candidates-preprocess` by a calling a new preprocessing function `acm-menu-candidates-preprocess`.
To get the current line in the original buffer (instead of the overlay buffer), I use `lsp-bridge--last-buffer`, looks a little strange... (any better way to do that??) or we should do it in `copliot.py` (still need to get the current line content though)

I added an option `acm-backend-copilot-show-trailing` to enable this behavior; default to false though, you can decide whether to make it the default (which I prefer).
