### PR TITLE
Enhance Remote SSH experience

### DIFF
--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -52,7 +52,9 @@ class RemoteFileClient(threading.Thread):
         self.callback = callback
         [self.remote_python_command, self.remote_python_file, self.remote_log] = get_emacs_vars(["lsp-bridge-remote-python-command", "lsp-bridge-remote-python-file", "lsp-bridge-remote-log"])
 
-        [self.user_ssh_private_key] = get_emacs_vars(["lsp-bridge-user-ssh-private-key"])
+        [self.user_ssh_private_key,
+         self.user_ssh_agent] = get_emacs_vars(["lsp-bridge-user-ssh-private-key",
+                                                "lsp-bridge-user-ssh-agent"])
 
         self.ssh = self.connect_ssh(
             ssh_conf.get('gssapiauthentication', 'no') in ('yes'),
@@ -91,6 +93,7 @@ class RemoteFileClient(threading.Thread):
         import paramiko
 
         ssh = paramiko.SSHClient()
+        ssh.load_system_host_keys()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         proxy = None
@@ -102,7 +105,8 @@ class RemoteFileClient(threading.Thread):
                 ssh.connect(self.ssh_host, port=self.ssh_port, username=self.ssh_user, gss_auth=True, gss_kex=True, sock=proxy)
             else:
                 # Login server with ssh private key.
-                ssh_private_key = self.ssh_private_key()
+                # Don't specify key_filename with ssh-agent (allow_agent is default to True)
+                ssh_private_key = self.ssh_private_key() if not self.user_ssh_agent else None
                 # look_for_keys defaults to True
                 # when user specify the SSH private key path
                 # disable searching for discoverable private key files in ~/.ssh/

--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -184,7 +184,7 @@ class RemoteFileClient(threading.Thread):
         _, stdout, stderr = self.ssh.exec_command(
             f"""
             nohup /bin/bash -l -c '
-            pid=$(ps aux | grep -v grep | grep lsp_bridge.py | awk '\\''{{print $2}}'\\'')
+            pid=$(pgrep -f '\\''lsp_bridge.py$'\\'')
             if [ "$pid" == "" ]; then
                 echo -e "Start lsp-bridge process as user $(whoami)" | tee >{remote_log}
                 {remote_python_command} {remote_python_file} >>{remote_log} 2>&1 &
@@ -207,7 +207,7 @@ class RemoteFileClient(threading.Thread):
             self.ssh.exec_command(
                 f"""
                 nohup /bin/bash -l -c '
-                pid=$(ps aux | grep -v grep | grep lsp_bridge.py | awk '\\''{{print $2}}'\\'')
+                pid=$(pgrep -f '\\''lsp_bridge.py$'\\'')
                 echo "try kill $pid" | tee >> {remote_log}
                 if ! [ "$pid" == "" ]; then
                     echo -e "kill lsp-bridge process as user $(whoami)" | tee >>{remote_log}

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -289,6 +289,12 @@ After set `lsp-bridge-completion-obey-trigger-characters-p' to nil, you need use
   :safe (lambda (v) (or (null v) (stringp v)))
   :group 'lsp-bridge)
 
+(defcustom lsp-bridge-user-ssh-agent nil
+  "use ssh-agent in SSH connections."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'lsp-bridge)
+
 (defcustom lsp-bridge-symbols-enable-which-func nil
   "Wether use lsp-bridge in which-func."
   :type 'boolean

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -402,7 +402,7 @@ class LspBridge:
         tramp_method_prefix = tramp_file_name.rsplit(":", 1)[0]
 
         if tramp_method_prefix.startswith("/ssh"):
-
+            alias = None
             # arguments are passed from emacs using standard TRAMP functions tramp-file-name-<field>
             if server_host in self.host_names:
                 server_host = self.host_names[server_host]['hostname']
@@ -418,7 +418,6 @@ class LspBridge:
                 ssh_conf = ssh_config.lookup(alias)
 
                 server_host = ssh_conf.get('hostname', server_host)
-                self.host_names[alias] = ssh_conf
 
             if not is_valid_ip(server_host):
                 if server_host in self.host_ip_dict:
@@ -434,6 +433,7 @@ class LspBridge:
                         message_emacs(f"Resolve {server_host} to {server_ip}")
                         server_host = server_ip
                         self.host_ip_dict[server_host] = server_ip
+                ssh_conf['hostname'] = server_ip # overwrite
 
             if not is_valid_ip(server_host):
                 message_emacs("HostName Must be IP format.")
@@ -443,6 +443,8 @@ class LspBridge:
             if ssh_port:
                 ssh_conf['port'] = ssh_port
             self.host_names[server_host] = ssh_conf
+            if alias:
+                self.host_names[alias] = ssh_conf
 
             tramp_connection_info = tramp_method_prefix + ":"
             self.remote_sync(server_host, tramp_connection_info)


### PR DESCRIPTION
I finally tested lsp-bridge with tramp (to compare with ssh + tmux + TUI emacs).

I have added some enhancements to fit my needs.

## 1. Allow the remote server and the local server to coexist. 
To differentiate them, I test whether it specified a port number when launching `lsp_bridge.py`; I also change to use `pgrep` instead of the original `ps + grep + awk`

## 2. Using SSH-Agent
Some of my key is encrypted, and I see the `Key is encrypted` errors like #769 #939 
I add all my keys (encrypted or unencrypted) to ssh-agent with Keychain (https://www.funtoo.org/Funtoo:Keychain), which manages the keys and adds them to ssh-agent.

I added a new option `lsp-bridge-user-ssh-agent` (default to false, so existing users will not notice the difference).
If turned on, it will not specify `key_filename` and paramiko will try to use keys in ssh-agent.

## 3. Resolve non-IP hostname with DNS
I tried to rework it to allow non-IP hostnames, but failed lol.
So, I used an easier way to resolve the IP with DNS and cache the result.

I test and it works with my ssh_config.
```
Host work
    Hostname work.home
    User yufu
    ForwardX11 yes
    ForwardX11Trusted yes
```
with tramp file path `/sshx:work:/home/yufu/x.py`
