### PR TITLE
[severity] set severity to error if not set

### DIFF
--- a/core/fileaction.py
+++ b/core/fileaction.py
@@ -336,7 +336,7 @@ class FileAction:
         diagnostic_count = 0
         for server_name in self.diagnostics:
             for diagnostic in self.diagnostics[server_name]:
-                if hide_severities and diagnostic["severity"] in hide_severities:
+                if hide_severities and diagnostic.get("severity", 1) in hide_severities:
                     continue
                 diagnostic["server-name"] = server_name
                 diagnostics.append(diagnostic)


### PR DESCRIPTION
ruff does not report severity for some errors (or all?)

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic

It's recommended to treat that as errors if the severity is omitted