### PR TITLE
Fix Imenu comprehension

### DIFF
--- a/lsp-bridge-imenu.el
+++ b/lsp-bridge-imenu.el
@@ -39,7 +39,7 @@ Possible values: `imenu', `consult-imenu', or `consult-imenu-multi'."
                                           (mapcar (lambda (s) (apply #'dfs s)) res)))
                                        (imenu-create-index-function #'(lambda () index-items))
                                        (last-nonmenu-event 13))
-                                  (call-interactively 'lsp-bridge-imenu-function))))
+                                  (call-interactively lsp-bridge-imenu-function))))
 
 (provide 'lsp-bridge-imenu)
 ;;; lsp-bridge-imenu.el ends here

--- a/multiserver/angular_template_html.json
+++ b/multiserver/angular_template_html.json
@@ -18,5 +18,6 @@
   "document_symbol": "vscode-html-language-server",
   "workspace_symbol": "vscode-html-language-server",
   "semantic_tokens": "vscode-html-language-server",
-  "inlay_hint": "vscode-html-language-server"
+  "inlay_hint": "vscode-html-language-server",
+  "imenu": "vscode-html-language-server"
 }

--- a/multiserver/angular_template_typescript.json
+++ b/multiserver/angular_template_typescript.json
@@ -18,5 +18,6 @@
   "document_symbol": "typescript",
   "workspace_symbol": "typescript",
   "semantic_tokens": "typescript",
-  "inlay_hint": "typescript"
+  "inlay_hint": "typescript",
+  "imenu": "typescript"
 }

--- a/multiserver/basedpyright_ruff.json
+++ b/multiserver/basedpyright_ruff.json
@@ -18,5 +18,6 @@
   "document_symbol": "basedpyright",
   "workspace_symbol": "basedpyright",
   "semantic_tokens": "basedpyright",
-  "inlay_hint": "basedpyright"
+  "inlay_hint": "basedpyright",
+  "imenu": "basedpyright"
 }

--- a/multiserver/css_emmet.json
+++ b/multiserver/css_emmet.json
@@ -18,5 +18,6 @@
   "document_symbol": "vscode-css-language-server",
   "workspace_symbol": "vscode-css-language-server",
   "semantic_tokens": "vscode-css-language-server",
-  "inlay_hint": "vscode-css-language-server"
+  "inlay_hint": "vscode-css-language-server",
+  "imenu": "vscode-css-language-server"
 }

--- a/multiserver/css_tailwindcss.json
+++ b/multiserver/css_tailwindcss.json
@@ -18,5 +18,6 @@
   "document_symbol": "vscode-css-language-server",
   "workspace_symbol": "vscode-css-language-server",
   "semantic_tokens": "vscode-css-language-server",
-  "inlay_hint": "vscode-css-language-server"
+  "inlay_hint": "vscode-css-language-server",
+  "imenu": "vscode-css-language-server"
 }

--- a/multiserver/html_emmet.json
+++ b/multiserver/html_emmet.json
@@ -18,5 +18,6 @@
   "document_symbol": "vscode-html-language-server",
   "workspace_symbol": "vscode-html-language-server",
   "semantic_tokens": "vscode-html-language-server",
-  "inlay_hint": "vscode-html-language-server"
+  "inlay_hint": "vscode-html-language-server",
+  "imenu": "vscode-html-language-server"
 }

--- a/multiserver/html_tailwindcss.json
+++ b/multiserver/html_tailwindcss.json
@@ -18,5 +18,6 @@
   "document_symbol": "vscode-html-language-server",
   "workspace_symbol": "vscode-html-language-server",
   "semantic_tokens": "vscode-html-language-server",
-  "inlay_hint": "vscode-html-language-server"
+  "inlay_hint": "vscode-html-language-server",
+  "imenu": "vscode-html-language-server"
 }

--- a/multiserver/jedi_ruff.json
+++ b/multiserver/jedi_ruff.json
@@ -18,5 +18,6 @@
   "document_symbol": "jedi",
   "workspace_symbol": "jedi",
   "semantic_tokens": "jedi",
-  "inlay_hint": "jedi"
+  "inlay_hint": "jedi",
+  "imenu": "jedi"
 }

--- a/multiserver/pylsp_ruff.json
+++ b/multiserver/pylsp_ruff.json
@@ -18,5 +18,6 @@
   "document_symbol": "pylsp",
   "workspace_symbol": "pylsp",
   "semantic_tokens": "pylsp",
-  "inlay_hint": "pylsp"
+  "inlay_hint": "pylsp",
+  "imenu": "pylsp"
 }

--- a/multiserver/pyright-background-analysis_ruff.json
+++ b/multiserver/pyright-background-analysis_ruff.json
@@ -18,5 +18,6 @@
   "document_symbol": "pyright-background-analysis",
   "workspace_symbol": "pyright-background-analysis",
   "semantic_tokens": "pyright-background-analysis",
-  "inlay_hint": "pyright-background-analysis"
+  "inlay_hint": "pyright-background-analysis",
+  "imenu": "pyright-background-analysis"
 }

--- a/multiserver/pyright_ruff.json
+++ b/multiserver/pyright_ruff.json
@@ -18,5 +18,6 @@
   "document_symbol": "pyright",
   "workspace_symbol": "pyright",
   "semantic_tokens": "pyright",
-  "inlay_hint": "pyright"
+  "inlay_hint": "pyright",
+  "imenu": "pyright"
 }

--- a/multiserver/python-ms_ruff.json
+++ b/multiserver/python-ms_ruff.json
@@ -18,5 +18,6 @@
   "document_symbol": "python-ms",
   "workspace_symbol": "python-ms",
   "semantic_tokens": "python-ms",
-  "inlay_hint": "python-ms"
+  "inlay_hint": "python-ms",
+  "imenu": "python-ms"
 }

--- a/multiserver/qmlls_javascript.json
+++ b/multiserver/qmlls_javascript.json
@@ -18,5 +18,6 @@
   "document_symbol": "qmlls",
   "workspace_symbol": "qmlls",
   "semantic_tokens": "qmlls",
-  "inlay_hint": "qmlls"
+  "inlay_hint": "qmlls",
+  "imenu": "qmlls"
 }

--- a/multiserver/typescript_eslint.json
+++ b/multiserver/typescript_eslint.json
@@ -18,5 +18,6 @@
   "document_symbol": "typescript",
   "workspace_symbol": "typescript",
   "semantic_tokens": "typescript",
-  "inlay_hint": "typescript"
+  "inlay_hint": "typescript",
+  "imenu": "typescript"
 }

--- a/multiserver/typescriptreact_eslint.json
+++ b/multiserver/typescriptreact_eslint.json
@@ -18,5 +18,6 @@
   "document_symbol": "typescriptreact",
   "workspace_symbol": "typescriptreact",
   "semantic_tokens": "typescriptreact",
-  "inlay_hint": "typescriptreact"
+  "inlay_hint": "typescriptreact",
+  "imenu": "typescriptreact"
 }

--- a/multiserver/volar_emmet.json
+++ b/multiserver/volar_emmet.json
@@ -18,5 +18,6 @@
   "document_symbol": "volar",
   "workspace_symbol": "volar",
   "semantic_tokens": "volar",
-  "inlay_hint": "volar"
+  "inlay_hint": "volar",
+  "imenu": "volar"
 }


### PR DESCRIPTION
Call the value of `lsp-bridge-imenu-function` instead of calling _it_.

Also fixed error when using multiserver:
```
Traceback (most recent call last):
  File "/home/deirn/.config/emacs/elpaca/builds/lsp-bridge/lsp_bridge.py", line 675, in event_dispatcher
    getattr(self, func_name)(*func_args)
  File "/home/deirn/.config/emacs/elpaca/builds/lsp-bridge/lsp_bridge.py", line 967, in _do
    action.call(name, *args)
  File "/home/deirn/Documents/github.com/deirn/fedoracfg/config/emacs/elpaca/repos/lsp-bridge/core/fileaction.py", line 171, in call
    method_server_names = [self.multi_servers_info[method]]
KeyError: 'imenu'
```