### PR TITLE
Breadcrumb: fix error when symbol has no child

### DIFF
--- a/core/handler/breadcrumb.py
+++ b/core/handler/breadcrumb.py
@@ -45,7 +45,7 @@ class Breadcrumb(Handler):
                     ):
                         cursor_symbol = child
 
-                    if child["children"]:
+                    if "children" in child and child["children"]:
                         traverse(child, child["children"])
 
             traverse(None, response)


### PR DESCRIPTION
Fix 
```
Traceback (most recent call last):
  File "/home/deirn/Documents/github.com/deirn/fedoracfg/config/emacs/elpaca/repos/lsp-bridge/core/handler/breadcrumb.py", line 51, in process_response
    traverse(None, response)
  File "/home/deirn/Documents/github.com/deirn/fedoracfg/config/emacs/elpaca/repos/lsp-bridge/core/handler/breadcrumb.py", line 48, in traverse
    if child["children"]:
KeyError: 'children'
```