### PR TITLE
check children in symbol

### DIFF
--- a/core/handler/document_symbol.py
+++ b/core/handler/document_symbol.py
@@ -29,7 +29,7 @@ class DocumentSymbol(Handler):
                             current_defun += '.'
                         current_defun += symbol['name']
                         symbols.append(symbol)
-                    if symbol["children"]:
+                    if "children" in symbol and symbol["children"]:
                         response.extend(reversed(symbol["children"]))
                 eval_in_emacs("lsp-bridge-symbols--record-current-defun", current_defun)
             except:


### PR DESCRIPTION
error log :
```
--- [01:34:56.649630] Recv $/progress notification from 'rust-analyzer' for project main.rs

--- [01:35:19.444912] Send textDocument/inlayHint request (41083) to 'rust-analyzer' for project main.rs
Traceback (most recent call last):
  File "/Users/gerald/.emacs.d/var/straight/repos/lsp-bridge/core/handler/document_symbol.py", line 32, in process_response
    if symbol["children"]:
       ~~~~~~^^^^^^^^^^^^
KeyError: 'children'
```