### PR TITLE
fix: do not show yasnippets candidates if minor mode not enabled

### DIFF
--- a/acm/acm-backend-yas.el
+++ b/acm/acm-backend-yas.el
@@ -170,6 +170,7 @@ Default matching use snippet filename."
 
 (defun acm-backend-yas-candidates (keyword)
   (when (and acm-enable-yas
+             yas-minor-mode
              (>= (length keyword) acm-backend-yas-candidate-min-length)
              (not (string-empty-p keyword)))
     (when (or acm-backend-yas--cache-expire-p


### PR DESCRIPTION
yas-expand-snippet needs yas-minor-mode enabled. Use the buffer local state to enable yas conditionally. Otherwise selecting candidates throws error message "‘yas-expand-snippet’ needs properly setup ‘yas-minor-mode’"