### PR TITLE
enhancement: Add zig-ts-mode into lsp-bridge-single-lang-server-mode-list

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -603,7 +603,7 @@ If nil, lsp-bridge would try to detect by default."
     (elm-mode   .                                                                "elm-language-server")
     ((php-mode php-ts-mode) .                                                    lsp-bridge-php-lsp-server)
     ((yaml-mode yaml-ts-mode) .                                                  "yaml-language-server")
-    (zig-mode .                                                                  "zls")
+    ((zig-mode zig-ts-mode) .                                                    "zls")
     ((dockerfile-mode dockerfile-ts-mode) .                                      "docker-langserver")
     (d-mode .                                                                    "serve-d")
     ((fortran-mode f90-mode) .                                                   "fortls")


### PR DESCRIPTION
Hi! 
I just add `zig-ts-mode` into `lsp-bridge-single-lang-server-mode-list` for `zls` mapping. As for `zig-ts-mode`, please refer to https://codeberg.org/meow_king/zig-ts-mode. 
Have a good day!