### PR TITLE
Completion: sort by filterText if it exist

### DIFF
--- a/core/handler/completion.py
+++ b/core/handler/completion.py
@@ -36,7 +36,7 @@ class Completion(Handler):
 
     def compare_candidates(self, x, y):
         prefix = self.prefix.lower()
-        x_label, y_label = x["label"].lower(), y["label"].lower()
+        x_label, y_label = (x["filterText"] or x["label"]).lower(), (y["filterText"] or y["label"]).lower()
         x_icon, y_icon = x["icon"], y["icon"]
         x_score, y_score = x["score"], y["score"]
         x_sort_text, y_sort_text = map(self.parse_sort_value, (x["sortText"], y["sortText"]))
@@ -191,6 +191,7 @@ class Completion(Handler):
                     "textEdit": item.get("textEdit", None),
                     "score": item.get("score", 1000),
                     "sortText": item.get("sortText", ""),
+                    "filterText": item.get("filterText", None),
                     "server": self.method_server_name,
                     "backend": "lsp"
                 }


### PR DESCRIPTION
fallback to label if it's not

---
The [specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem) said that `filterText` should be used instead of `label` for filtering if it exists.
For example, in Dart, `Flutter Stateful Widget` has the `filterText` be `stful`.

Before:
<img width="735" height="192" alt="Screenshot From 2025-08-22 16-47-30" src="https://github.com/user-attachments/assets/ce0015b3-c81e-4a9b-ad89-3f8497589213" />

After:
<img width="737" height="193" alt="Screenshot From 2025-08-22 18-17-29" src="https://github.com/user-attachments/assets/49cd8203-5fa6-4460-97ab-b8a585999d18" />

This is more in line to what VS Code does:
<img width="487" height="267" alt="image" src="https://github.com/user-attachments/assets/a589f883-9e94-4c63-ab79-ed3d0372f3f5" />

~~I think changing the `label` value to `filterText` is fine, since what is shown in Emacs is `displayLabel`, but please do check on that.~~ Changed to use separate value as I found it's used somewhere else.
