### PR TITLE
Breadcrumb: disable breadcrumb-mode when can't call lsp-bridge file api

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -98,6 +98,7 @@
 (require 'lsp-bridge-dart)
 (require 'lsp-bridge-semantic-tokens)
 (require 'lsp-bridge-rust)
+(require 'lsp-bridge-breadcrumb)
 
 (defgroup lsp-bridge nil
   "LSP-Bridge group."


### PR DESCRIPTION
also add `(require 'lsp-bridge-breadcrumb) in lsp-bridge.el