### PR TITLE
Improve doc frame positioning and add boundary constraint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ lsp-bridge provides support for more than two language servers for many language
 - `acm-enable-citre`: Integration with [citre(ctags)](https://github.com/universal-ctags/citre). Enable this to add citre (ctags) backend (disabled by default)
 - `acm-enable-lsp-workspace-symbol`: Enable LSP workspace symbol completion, disabled by default
 - `acm-doc-frame-max-lines`: Max line number of help documentation, default is 20
+- `acm-doc-frame-boundary`: Boundary constraint for documentation frame positioning, options include `'parent-frame`, `'display`, default is `'parent-frame`. `'parent-frame` constrains the doc frame within the parent Emacs frame, `'display` allows the doc frame to extend beyond Emacs frame but within display screen boundaries
 - `acm-candidate-match-function`: lsp-bridge frontend filter algorithm for candidates, options include `'regexp-quote`, `'orderless-flex`, `'orderless-literal`, `'orderless-prefixes`, `'orderless-regexp`, `'orderless-initialism`, default is `regexp-quote`, orderless-* started algorithms require additional installation of [orderless](https://github.com/oantolin/orderless)
 - `acm-completion-mode-candidates-merge-order`: Customize the order of the mode candidates, the display order for mode candidates, default order: Elisp、 LSP、 Jupyter、 Tabby Ctags、 Citre、 ROAM、 Word、 Telegra
 - `acm-backend-lsp-candidate-min-length`: The minimum characters to trigger lsp completion, default is 0

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -328,6 +328,7 @@ lsp-bridge 针对许多语言都提供 2 个以上的语言服务器支持， �
 - `acm-enable-citre`: [citre(ctags)](https://github.com/universal-ctags/citre) 补全， 默认关闭
 - `acm-enable-lsp-workspace-symbol`: LSP 符号补全， 默认关闭
 - `acm-doc-frame-max-lines`: 帮助窗口的最大行数， 默认是 20
+- `acm-doc-frame-boundary`: 文档框架的边界约束策略，选项包括 `'parent-frame`、`'display`，默认为 `'parent-frame`。`'parent-frame` 将文档框架限制在父 Emacs 窗口内，`'display` 允许文档框架超出 Emacs 窗口但不超出显示器边界
 - `acm-candidate-match-function`: lsp-bridge 前端对补全候选词的过滤算法， 选项有 `'regexp-quote`, `'orderless-flex`, `'orderless-literal`, `'orderless-prefixes`, `'orderless-regexp`, `'orderless-initialism`, 默认为 `regexp-quote`， orderless-\* 开头的算法需要额外安装 [orderless](https://github.com/oantolin/orderless)
 - `acm-completion-mode-candidates-merge-order`: 模式补全的显示顺序， 默认是按照 Elisp、 LSP、 Jupyter、 Ctags、 Citre、 ROAM、 单词、 Telegra 的顺序显示， 你可以根据你的需求调整模式补全的显示顺序
 - `acm-backend-lsp-candidate-min-length`: LSP 补全最小的触发字符数, 默认是 0


### PR DESCRIPTION
This PR fixes a bug where the documentation frame would overflow beyond the bottom screen edge and adds a configuration option for boundary constraints.

## Changes:
Fixed bottom overflow bug: Documentation frame no longer gets cut off when positioned near the bottom of the screen. It now automatically repositions upward when there's insufficient space below
Enhanced space utilization: Documentation frame can now use up to the full Emacs frame size while respecting display boundaries
Configurable boundary constraint: Added acm-doc-frame-boundary option allowing users to choose between:
* 'parent-frame (default): Constrain doc frame within Emacs window
* 'display: Allow doc frame to extend beyond Emacs window but within display screen

## Screenshots(the yellow lines are the border of the emacs frame)
### bottom screen edge (Before)

<img width="3444" height="306" alt="telegram-cloud-document-5-6165932170570372739" src="https://github.com/user-attachments/assets/f2aed12f-8f34-450f-8149-66a10e72f6f5" />

### bottom screen edge (Fixed)

![telegram-cloud-photo-size-5-6165932171026615016-y](https://github.com/user-attachments/assets/50cd4418-70b8-4e5d-b20b-3c5654578793)

### doc frame size (default, acm-doc-frame-boundary: parent-frame)

<img width="2362" height="1082" alt="8566fa67c2c10f6f180769e395f85233" src="https://github.com/user-attachments/assets/a7562c5b-4da4-4e96-967b-c34de3650559" />

### doc frame size (acm-doc-frame-boundary: display)

![telegram-cloud-photo-size-5-6165932171026615021-y](https://github.com/user-attachments/assets/cad7809c-22e8-488d-a19d-58fdad98582b)

