### PR TITLE
Add ruby-lsp config

### DIFF
--- a/langserver/ruby-lsp.json
+++ b/langserver/ruby-lsp.json
@@ -1,0 +1,29 @@
+{
+  "name": "ruby-lsp",
+  "languageId": "ruby",
+  "command": ["ruby-lsp"],
+  "settings": {},
+  "initializationOptions": {
+    "enabledFeatures": {
+      "codeActions": true,
+      "codeLens": true,
+      "completion": true,
+      "definition": true,
+      "diagnostics": true,
+      "documentHighlights": true,
+      "documentLink": true,
+      "documentSymbols": true,
+      "foldingRanges": true,
+      "formatting": true,
+      "hover": true,
+      "inlayHint": true,
+      "onTypeFormatting": true,
+      "selectionRanges": true,
+      "semanticHighlighting": true,
+      "signatureHelp": true,
+      "typeHierarchy": true,
+      "workspaceSymbol": true
+    },
+    "formatter": "auto"
+  }
+}


### PR DESCRIPTION
Adds [ruby-lsp](https://shopify.github.io/ruby-lsp/) langserver. 

The [README states to add a mode and hooks](https://github.com/manateelazycat/lsp-bridge?tab=readme-ov-file#add-support-for-new-language) for the new config but those already exist for ruby. I am not sure how to proceed. You wouldn't typically run both at the same time so it doesn't make sense to set up as a multiserver.

### Usage:
```el
(add-to-list 'lsp-bridge-single-lang-server-mode-list '(ruby-mode . "ruby-lsp"))
(add-to-list 'lsp-bridge-single-lang-server-mode-list '(ruby-ts-mode . "ruby-lsp"))
 ```
 
 ### Known Issues:
 - Formatting fails due to `update_file` in `fileaction.py` sending a whole document change (`send_whole_change_notification`) instead of a ranged changed.
    -  [See this comment from the creator about whole document changes vs incremental](https://github.com/Shopify/ruby-lsp/issues/3148#issuecomment-2642785478).
 - Text turns white after formatting (with a patched version to fix the above issue)
    - I believe it's due to `(inhibit-modification-hooks t)` in `defun lsp-bridge-format--update`. If I replace it with `(gc-cons-threshold most-positive-fixnum)` the issue goes away. I don't know emacs or elisp very well so this may be incorrect