### PR TITLE
Add source and code to diagnostic message

### DIFF
--- a/lsp-bridge-diagnostic.el
+++ b/lsp-bridge-diagnostic.el
@@ -208,6 +208,9 @@ You can set this value with `(2 3 4) if you just need render error diagnostic."
                                                                 (make-overlay diagnostic-start (1+ diagnostic-start))
                                                               (make-overlay diagnostic-start diagnostic-end)))
                                                    (message (plist-get diagnostic :message))
+                                                   (source (plist-get diagnostic :source))
+                                                   (code (plist-get diagnostic :code))
+
                                                    (overlay-face (cl-case severity
                                                                    (1 'lsp-bridge-diagnostics-error-face)
                                                                    (2 'lsp-bridge-diagnostics-warning-face)
@@ -219,7 +222,7 @@ You can set this value with `(2 3 4) if you just need render error diagnostic."
                                               (overlay-put overlay
                                                            'display-message
                                                            (if (> diagnostic-number 1)
-                                                               (format "[%s:%s] %s" (1+ diagnostic-index) diagnostic-number message)
+                                                               (format "[%s:%s] %s %s(%s)" (1+ diagnostic-index) diagnostic-number message source code)
                                                              message))
                                               (push overlay lsp-bridge-diagnostic-overlays))))
 


### PR DESCRIPTION
Adds the diagnostic source server and the diagnostic code. 

Fixes #1220 

### Screenshots
#### VSCode
<img width="766" height="168" alt="Screenshot 2025-09-04 at 9 12 18 PM" src="https://github.com/user-attachments/assets/6898270f-dca0-4204-9cab-056b79946036" />

#### LSP-Bridge
<img width="852" height="82" alt="Screenshot 2025-09-04 at 9 12 46 PM" src="https://github.com/user-attachments/assets/556ad227-3d88-4e27-a3c2-4b1aa100d412" />

