### PR TITLE
add move init option

### DIFF
--- a/langserver/move-analyzer.json
+++ b/langserver/move-analyzer.json
@@ -2,5 +2,10 @@
   "name": "move-analyzer",
   "languageId": "move",
   "command": ["move-analyzer"],
-  "settings": {}
+  "settings": {},
+  "initializationOptions": {
+    "autoImports": true,
+    "inlayHintsType": true,
+    "inlayHintsParam": true
+  }
 }


### PR DESCRIPTION
see https://github.com/MystenLabs/sui/blob/eef60efd56b80cabf3c808602723988a24995c4a/external-crates/move/crates/move-analyzer/src/analyzer.rs#L187C5-L208C7

There are three init options here, so enable them in the json file.