### PR TITLE
make sure only one process started

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1317,7 +1317,8 @@ So we build this macro to restore postion after code format."
 
 (defun lsp-bridge-start-process ()
   "Start LSP-Bridge process if it isn't started."
-  (if (lsp-bridge-process-live-p)
+  (if (and (process-live-p lsp-bridge-server)
+           (process-live-p lsp-bridge-internal-process))
       (remove-hook 'post-command-hook #'lsp-bridge-start-process)
     ;; start epc server and set `lsp-bridge-server-port'
     (lsp-bridge--start-epc-server)


### PR DESCRIPTION
Since `lsp-bridge-epc-process` is set only after the Python server called `lsp-bridge--first-start`, `lsp-bridge-process-live-p` can return nil even if the Emacs-side process is already started.

This introduces race condition when switching to new buffer too quickly before the server calls first-start, making the server started again.