### PR TITLE
enable typescript inlayhint

### DIFF
--- a/langserver/typescript.json
+++ b/langserver/typescript.json
@@ -5,7 +5,20 @@
     "typescript-language-server",
     "--stdio"
   ],
-  "settings": {},
+  "settings": {
+    "typescript":{
+      "inlayHints": {
+        "includeInlayParameterNameHints": "all",
+        "includeInlayParameterNameHintsWhenArgumentMatchesName": true,
+        "includeInlayFunctionParameterTypeHints": true,
+        "includeInlayVariableTypeHints": true,
+        "includeInlayVariableTypeHintsWhenTypeMatchesName": true,
+        "includeInlayPropertyDeclarationTypeHints": true,
+        "includeInlayFunctionLikeReturnTypeHints": true,
+        "includeInlayEnumMemberValueHints": true
+      }
+    }
+  },
   "initializationOptions": {
     "preferences": {
 	  "includeCompletionsForModuleExports": false


### PR DESCRIPTION
```
[language].inlayHints.includeInlayEnumMemberValueHints: boolean;
[language].inlayHints.includeInlayFunctionLikeReturnTypeHints: boolean;
[language].inlayHints.includeInlayFunctionParameterTypeHints: boolean;
[language].inlayHints.includeInlayParameterNameHints: 'none' | 'literals' | 'all';
[language].inlayHints.includeInlayParameterNameHintsWhenArgumentMatchesName: boolean;
[language].inlayHints.includeInlayPropertyDeclarationTypeHints: boolean;
[language].inlayHints.includeInlayVariableTypeHints: boolean;
[language].inlayHints.includeInlayVariableTypeHintsWhenTypeMatchesName: boolean;
```
copy from https://github.com/typescript-language-server/typescript-language-server/blob/master/docs/configuration.md