### PR TITLE
Update python-lsp-bridge shebang line

### DIFF
--- a/python-lsp-bridge
+++ b/python-lsp-bridge
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_PATH=$(realpath "$0")
 SCRIPT_DIR_PATH=$(dirname "$SCRIPT_PATH")
 exec uv --directory="$SCRIPT_DIR_PATH" run python "$@"


### PR DESCRIPTION
### Summary

The original shebang line for `python-lsp-bridge` is `#!/bin/bash`, which does not exist for distro like NixOS. This will cause `No such file or directory` error on any distro that doesn't put bash on `/bin/bash`. For portability concern, it is better to use `#!/usr/bin/env bash` instead.

### Changes
- Change shebang line of `python-lsp-bridge` to `/usr/bin/env bash`