### PR TITLE
feat: constrain python version to exclude 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lsp-bridge"
 version = "0.1.0"
-requires-python = ">=3.13"
+requires-python = ">=3.13,<3.14"
 dependencies = [
     "epc>=0.0.5",
     "orjson>=3.10.18",


### PR DESCRIPTION
Update requires-python constraint from >=3.13 to >=3.13,<3.14 to prevent compatibility issues with Python 3.14.

#1256 

A minor change that helps keep the project working out of the box.