### PR TITLE
Fix regexp matching when reference buffer has no trailing newline

### DIFF
--- a/core/handler/find_implementation.py
+++ b/core/handler/find_implementation.py
@@ -53,5 +53,6 @@ class FindImplementation(Handler):
                     references_counter += 1
 
             linecache.clearcache()  # clear line cache
+            references_content += "\n"
 
             eval_in_emacs("lsp-bridge-references--popup", references_content, references_counter, self.pos)

--- a/core/handler/find_references.py
+++ b/core/handler/find_references.py
@@ -52,5 +52,6 @@ class FindReferences(Handler):
                     references_counter += 1
 
             linecache.clearcache()  # clear line cache
+            references_content += "\n"
 
             eval_in_emacs("lsp-bridge-references--popup", references_content, references_counter, self.pos)


### PR DESCRIPTION
lsp-bridge-ref-remove-lines-under-file relies on lsp-bridge-ref-regexp-split-line,
which fails to match at the end of the reference buffer when it does not end with a newline.