### PR TITLE
check variable is not null

### DIFF
--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -712,6 +712,8 @@ class LspBridge:
             lang_server_info = load_single_server_info(single_lang_server)
             #TODO support diagnostic
             lsp_server = self.create_lsp_server(filepath, project_path, lang_server_info, enable_diagnostics=False)
+            if not lsp_server:
+                return False
             create_file_action_with_single_server(filepath, lang_server_info, lsp_server)
         elif multi_lang_server:
             # Try to load multi language server when get-multi-lang-server return match one.
@@ -940,6 +942,8 @@ class LspBridge:
                 lang_server_info = load_single_server_info(current_lang_server)
                 server = self.create_lsp_server(filepath, action.single_server.project_path,
                                                 lang_server_info, enable_diagnostics=False)
+                if not server:
+                    return
                 action.org_lang_servers[lsp_server_name] = server
                 action.org_server_infos[lsp_server_name] = lang_server_info
                 server.attach(action)


### PR DESCRIPTION
```
Traceback (most recent call last):
    File "/Users/gerald/.emacs.d/var/straight/build-30.2/lsp-bridge/lsp_bridge.py", line 675, in event_dispatcher
      getattr(self, func_name)(*func_args)                                                                                                                                      ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^                             
    File "/Users/gerald/.emacs.d/var/straight/build-30.2/lsp-bridge/lsp_bridge.py", line 960, in _do
      open_file_success = self.open_file(filepath)  # _do is called inside event_loop, so we can block here.
    File "/Users/gerald/.emacs.d/var/straight/build-30.2/lsp-bridge/lsp_bridge.py", line 715, in open_file
      create_file_action_with_single_server(filepath, lang_server_info, lsp_server)
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/gerald/.emacs.d/var/straight/repos/lsp-bridge/core/fileaction.py", line 41, in create_file_action_with_single_server
      action = FileAction(filepath, single_server_info, single_server, None, None, external_file_link)
    File "/Users/gerald/.emacs.d/var/straight/repos/lsp-bridge/core/fileaction.py", line 89, in __init__
      self.org_lang_servers[self.single_server.server_name] = self.single_server
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  AttributeError: 'bool' object has no attribute 'server_name'
```