### PR TITLE
fix: clean up internal process on restart

### DIFF
--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1448,6 +1448,7 @@ So we build this macro to restore postion after code format."
     (when (get-buffer lsp-bridge-name)
       (kill-buffer lsp-bridge-name))
     (setq lsp-bridge-epc-process nil)
+    (setq lsp-bridge-internal-process nil)
     (message "[LSP-Bridge] Process terminated.")))
 
 (defun lsp-bridge--first-start (lsp-bridge-epc-port)


### PR DESCRIPTION
I experience issue when i restart the lsp server but the process is not restarting (i don't see the `*lsp-bridge*` buffer showing up)

not sure if this is a correct fix or the clean up should happen somewhere else