### PR TITLE
fix(tabnine): use packaging.version for Python 3.12+

### DIFF
--- a/core/tabnine.py
+++ b/core/tabnine.py
@@ -33,12 +33,8 @@ if version_info[1] < 12:
     from distutils.version import StrictVersion
     version_function = StrictVersion
 else:
-    try:
-        from packaging.version import Version
-        version_function = Version
-    except ImportError:
-        from pkg_resources import parse_version
-        version_function = parse_version
+    from packaging.version import Version
+    version_function = Version
 
 TABNINE_PROTOCOL_VERSION = "1.0.14"
 TABNINE_EXECUTABLE = "TabNine.exe" if get_os_name() == "windows" else "TabNine"


### PR DESCRIPTION
## Summary

- `setuptools` 82+ removed `pkg_resources` as a top-level module, causing `ModuleNotFoundError` on Python 3.12.x
- The previous `elif` condition (`version_info[1] >= 13 and version_info[2] > 1`) incorrectly excluded Python 3.12 and early patch releases of 3.13
- Since `packaging` is already a declared dependency of lsp-bridge, simply use `packaging.version.Version` for all Python >= 3.12

Follows up on #1127.