### PR TITLE
Fix Org Babel LSP position handling

### DIFF
--- a/acm/acm-backend-lsp.el
+++ b/acm/acm-backend-lsp.el
@@ -306,7 +306,25 @@ If optional MARKER, return a marker instead"
   (save-excursion
     (save-restriction
       (widen)
-      (goto-char (point-min))
+      (goto-char
+       (or (and (bound-and-true-p lsp-bridge-enable-org-babel)
+                (derived-mode-p 'org-mode)
+                ;; Org-babel servers speak in src-block-relative positions, not
+                ;; whole-buffer positions. Start conversion at the current block
+                ;; body so LSP text edits land inside the block instead of near
+                ;; the top of the Org buffer.
+                (or (and (boundp 'lsp-bridge-org-babel--block-bop)
+                         lsp-bridge-org-babel--block-bop)
+                    (when-let* ((element (or (and (boundp 'lsp-bridge-org-babel--info-cache)
+                                                  lsp-bridge-org-babel--info-cache)
+                                             (ignore-errors
+                                               (org-element-lineage (org-element-context) '(src-block) t)))))
+                      (or (org-element-property :contents-begin element)
+                          (save-excursion
+                            (goto-char (org-element-property :begin element))
+                            (forward-line 1)
+                            (point))))))
+           (point-min)))
       (forward-line (min most-positive-fixnum
                          (plist-get pos-plist :line)))
       (unless (eobp) ;; if line was excessive leave point at eob

--- a/core/fileaction.py
+++ b/core/fileaction.py
@@ -202,6 +202,17 @@ class FileAction:
                 return
             start['line'] -= self.org_line_bias
             end['line'] -= self.org_line_bias
+            if start['line'] < 0 or end['line'] < 0:
+                logger.warning(
+                    "Skip incremental org didChange with invalid rebased range: "
+                    "start=%s end=%s org_line_bias=%s buffer=%s",
+                    start, end, self.org_line_bias, buffer_name
+                )
+                # Org src-block position tracking can drift after commands that
+                # move point outside the cached block. Fall back to a full sync
+                # so we do not send invalid negative positions to the LSP server.
+                self.update_file(buffer_name, self.org_line_bias)
+                return
 
         buffer_content = ''
         # Send didChange request to LSP server.


### PR DESCRIPTION
Treat Org Babel LSP text edits as relative to the current src block body when applying ACM completion edits, and guard incremental didChange updates against negative rebased ranges by falling back to a full update. This prevents completion from jumping to the top of the Org buffer and stops invalid didChange positions from crashing rust-analyzer.