### PR TITLE
fix(acm): remove existing text before inserting auto complete content

### DIFF
--- a/acm/acm.el
+++ b/acm/acm.el
@@ -797,8 +797,10 @@ The key of candidate will change between two LSP results."
 
     (if (fboundp candidate-expand)
         (funcall candidate-expand candidate-info bound-start)
-      (delete-region bound-start (point))
-      (insert (plist-get candidate-info :label))))
+      (let* ((bounds (acm-get-input-prefix-bound))
+             (bound-end (if bounds (cdr bounds) (point))))
+        (delete-region bound-start (max (point) bound-end))
+        (insert (plist-get candidate-info :label)))))
 
   (when (overlayp acm-preview-overlay)
     (delete-overlay acm-preview-overlay))


### PR DESCRIPTION
when the cursor is in following pos

`("S" "Snake_Case" string-inflection-<cursor>-snake-case)]`

and choosing `string-inflection-capital-snake-case` from auto complete

currently, it will insert the full completion like `string-inflection-capital-snake-case-snake-case`

it should complete to `string-inflection-capital-snake-case` instead