### PR TITLE
fix: remove trailing comma from qmlls JSON config

### DIFF
--- a/multiserver/qmlls_javascript.json
+++ b/multiserver/qmlls_javascript.json
@@ -1,5 +1,5 @@
 {
   "default": "qmlls",
   "completion": ["qmlls", "javascript"],
-  "completion_item_resolve": ["qmlls", "javascript"],
+  "completion_item_resolve": ["qmlls", "javascript"]
 }

--- a/test/test_langserver.py
+++ b/test/test_langserver.py
@@ -1,0 +1,21 @@
+import json
+import unittest
+from pathlib import Path
+
+from test.common import BASE_DIR
+
+_LANG_SERVER_DIR = BASE_DIR / "langserver"
+_MULTI_SERVER_DIR = BASE_DIR / "multiserver"
+
+
+class LangServerJson(unittest.TestCase):
+    def test_json_content(self) -> None:
+        def _check_json(p: Path) -> None:
+            with open(p, "r", encoding="utf-8") as f:
+                json.load(f)
+
+        for d in (_LANG_SERVER_DIR, _MULTI_SERVER_DIR):
+            for f in d.iterdir():
+                if f.is_file() and f.suffix == ".json":
+                    with self.subTest(file=f):
+                        _check_json(f)


### PR DESCRIPTION

1. Fixed a trailing comma in `multiserver/qmlls_javascript.json` that caused lsp-bridge to crash. See the log below.
2. Added tests to verify that the LSP JSON files can be loaded successfully.

```
Traceback (most recent call last):
  File "/home/xxx/.emacs.d/site-lisp/lsp-bridge/lsp_bridge.py", line 707, in event_dispatcher
    getattr(self, func_name)(*func_args)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/xxx/.emacs.d/site-lisp/lsp-bridge/lsp_bridge.py", line 1002, in _do
    open_file_success = self.open_file(filepath)  # _do is called inside event_loop, so we can block here.
  File "/home/xxx/.emacs.d/site-lisp/lsp-bridge/lsp_bridge.py", line 761, in open_file
    multi_lang_server_info = json.load(f)
  File "/home/xxx/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/json/__init__.py", line 298, in load
    return loads(
        fp.read(),
        cls=cls,
        object_hook=object_hook,
        parse_float=parse_float,
        parse_int=parse_int,
        parse_constant=parse_constant,
        object_pairs_hook=object_pairs_hook,
        **kw,
    )
  File "/home/xxx/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/json/__init__.py", line 352, in loads
    return _default_decoder.decode(s)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/home/xxx/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/json/decoder.py", line 345, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xxx/.local/share/uv/python/cpython-3.13.13-linux-x86_64-gnu/lib/python3.13/json/decoder.py", line 361, in raw_decode
    obj, end = self.scan_once(s, idx)
               ~~~~~~~~~~~~~~^^^^^^^^
json.decoder.JSONDecodeError: Illegal trailing comma before end of object: line 4 column 53 (char 117)
```