### PR TITLE
Show LSP initialization progress in mode-line & Improve cursor positioning for type inlay hints

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -799,7 +799,7 @@ class LspServer:
             ("rename_prepare_provider", ["result", "capabilities", "renameProvider", "prepareProvider"]),
             ("code_action_provider", ["result", "capabilities", "codeActionProvider"]),
             ("code_action_kinds", ["result", "capabilities", "codeActionProvider", "codeActionKinds"]),
-            ("document_highlight_provider", ["result", "capabilities", "documentHighlightProvider"]),            
+            ("document_highlight_provider", ["result", "capabilities", "documentHighlightProvider"]),
             ("code_format_provider", ["result", "capabilities", "documentFormattingProvider"]),
             ("range_format_provider", ["result", "capabilities", "documentRangeFormattingProvider"]),
             ("signature_help_provider", ["result", "capabilities", "signatureHelpProvider"]),
@@ -905,7 +905,8 @@ class LspServer:
                     progress_message += str(message_attr)
 
             if progress_message != "":
-                eval_in_emacs("lsp-bridge--record-work-done-progress", "[LSP-Bridge] " + progress_message)
+                file_paths = list(self.files.keys())
+                eval_in_emacs("lsp-bridge--record-work-done-progress", "[LSP-Bridge] " + progress_message, file_paths)
 
     def handle_register_capability_message(self, message):
         if "method" in message and message["method"] in ["client/registerCapability"]:

--- a/lsp-bridge-inlay-hint.el
+++ b/lsp-bridge-inlay-hint.el
@@ -171,8 +171,8 @@
                 (dolist (hint inlay-hints)
                   (goto-char (acm-backend-lsp-position-to-point (plist-get hint :position)))
                   (let* ((hint-kind (plist-get hint :kind))
-                         ;; InlayHintKind is 1 mean is an inlay hint that for a type annotation.
-                         ;; 2 mean is an inlay hint that is for a parameter.
+                         ;; InlayHintKind is 1 mean is an inlay hint that for a type annotation. (rendered after variable),
+                         ;; 2 mean is an inlay hint that is for a parameter. (rendered before argument).
                          ;; type annotation is hint need render at end of line, we use `after-string' overlay to implement it.
                          (hint-render-use-after-string-p (eql hint-kind 1))
                          ;; Hint text need concat padding-left, label and padding-right.
@@ -180,20 +180,22 @@
                                      (lsp-bridge-inlay-hint-padding-text (plist-get hint :paddingLeft) t)
                                      (lsp-bridge-inlay-hint-label-text (plist-get hint :label))
                                      (lsp-bridge-inlay-hint-padding-text (plist-get hint :paddingRight) nil)))
+                         ;; For type hints (kind=1), add `cursor 1' so the cursor stops at the
+                         ;; start of the hint text instead of jumping past it when moving right.
+                         ;; See https://github.com/emacs-lsp/lsp-mode/issues/3263
+                         (hint-text-propertized
+                          (if hint-render-use-after-string-p
+                              (propertize hint-text 'face 'lsp-bridge-inlay-hint-face 'cursor 1)
+                            (propertize hint-text 'face 'lsp-bridge-inlay-hint-face)))
                          (overlay (if hint-render-use-after-string-p
                                       (make-overlay (point) (1+ (point)) nil t)
                                     (make-overlay (1- (point)) (point) nil nil nil))))
-                    (when (and (equal hint-index 0)
-                               hint-render-use-after-string-p)
-                      (put-text-property 0 1 'cursor 1 hint-text))
                     (overlay-put overlay
                                  (if hint-render-use-after-string-p 'before-string 'after-string)
-                                 (propertize hint-text 'face 'lsp-bridge-inlay-hint-face))
-                    (overlay-put overlay 'evaporate t) ; NOTE, `evaporate' is import
+                                 hint-text-propertized)
+                    (overlay-put overlay 'evaporate t) ; NOTE, `evaporate' is important
                     (push overlay lsp-bridge-inlay-hint-overlays)
-
-                    (setq hint-index (1+ hint-index))
-                    )))))))))
+                    (setq hint-index (1+ hint-index)))))))))))
 
 (defun lsp-bridge-inlay-hint-retry (filepath)
   "InlayHint will got error 'content modified' error if it followed immediately by a didChange request.

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -2508,6 +2508,12 @@ Default is `bottom-right', you can choose other value: `top-left', `top-right', 
 
 (defvar lsp-bridge--last-buffer nil)
 
+(defvar-local lsp-bridge--work-done-progress nil
+  "Buffer local LSP work-done progress message for the mode line.")
+
+(defvar-local lsp-bridge--work-done-progress-timer nil
+  "Buffer-local Timer to clear `lsp-bridge--work-done-progress' after inactivity.")
+
 (defun lsp-bridge-monitor-window-buffer-change ()
   ;; Hide completion, diagnostic and signature frame when buffer or window changed.
   (unless (eq (current-buffer)
@@ -3074,10 +3080,54 @@ We need exclude `markdown-code-fontification:*' buffer in `lsp-bridge-monitor-be
   "Add `lsp-bridge-symbols-current-defun' to `which-func-functions'."
   lsp-bridge-symbols-current-defun)
 
-(defun lsp-bridge--record-work-done-progress (progress)
+
+(defun lsp-bridge--record-work-done-progress (progress file-paths)
+  ;; Optional message output, controlled by acm-backend-lsp-show-progress.
   (when acm-backend-lsp-show-progress
     (unless (active-minibuffer-window)
-      (message progress))))
+      (message progress)))
+  ;; Update mode-line progress indicator.
+  (dolist (filepath file-paths)
+    (when-let* ((buf (lsp-bridge-get-match-buffer-by-filepath filepath)))
+      (with-current-buffer buf
+        (when lsp-bridge--work-done-progress-timer
+          (cancel-timer lsp-bridge--work-done-progress-timer)
+          (setq-local lsp-bridge--work-done-progress-timer nil))
+        (setq-local lsp-bridge--work-done-progress
+                    (if (string-equal progress "")
+                        nil
+                      (lsp-bridge--format-progress-message progress)))
+        (unless (string-equal progress "")
+          (let ((buf buf))
+            (setq-local lsp-bridge--work-done-progress-timer
+                        (run-with-timer 1 nil
+                                        (lambda ()
+                                          (when (buffer-live-p buf)
+                                            (with-current-buffer buf
+                                              (setq lsp-bridge--work-done-progress nil)
+                                              (force-mode-line-update t))))))))
+        (force-mode-line-update)))))
+
+(defun lsp-bridge--format-progress-message (progress)
+  "Extract progress percentage and icon from raw LSP string."
+  (let* (;; 1. Regex to extract the percentage like (96%%)
+         ;; We look for the pattern in parentheses
+         (percent-match (string-match "\\(([0-9]+%%)\\)" progress))
+         (percent (if percent-match
+                      (match-string 1 progress)
+                    ""))
+         ;; 2. Define the icon
+         (icon (when (fboundp 'nerd-icons-codicon)
+                 (nerd-icons-codicon "nf-cod-sync"))))
+
+    (if (string-blank-p percent)
+        ;; If no percentage found, return empty (or a minimal label if needed)
+        ""
+      ;; Final format: Icon + Percentage
+      ;; We remove the inner parentheses for a cleaner look, e.g., "96%%"
+      (format "%s %s"
+              (or icon "")
+              (replace-regexp-in-string "[()]" "" percent)))))
 
 ;;; Mode-line
 ;;;
@@ -3102,7 +3152,11 @@ We need exclude `markdown-code-fontification:*' buffer in `lsp-bridge-monitor-be
                 'lsp-bridge-kill-mode-line))
 
   (when lsp-bridge-server
-    (propertize "lsp-bridge"'face mode-face)))
+    (concat (propertize "lsp-bridge"'face mode-face)
+            (when lsp-bridge--work-done-progress
+              (propertize (concat " " lsp-bridge--work-done-progress)
+                          'face 'lsp-bridge-alive-mode-line)))
+    ))
 
 (when lsp-bridge-enable-mode-line
   (add-to-list 'mode-line-misc-info

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -3109,25 +3109,26 @@ We need exclude `markdown-code-fontification:*' buffer in `lsp-bridge-monitor-be
         (force-mode-line-update)))))
 
 (defun lsp-bridge--format-progress-message (progress)
-  "Extract progress percentage and icon from raw LSP string."
-  (let* (;; 1. Regex to extract the percentage like (96%%)
-         ;; We look for the pattern in parentheses
+  "Format progress message for mode-line display."
+  (let* (;; Extract percentage like (96%%)
          (percent-match (string-match "\\(([0-9]+%%)\\)" progress))
          (percent (if percent-match
-                      (match-string 1 progress)
+                      (replace-regexp-in-string "[()]" "" (match-string 1 progress))
                     ""))
-         ;; 2. Define the icon
+         ;; Extract stage name: strip rustAnalyzer/ prefix, take word before space/paren
+         (stage (when (string-match "\\(?:rustAnalyzer/\\)?\\([A-Za-z ]+?\\)\\(?:[[:space:]]*(\\|[[:space:]]+[0-9]\\|$\\)" progress)
+                  (string-trim (match-string 1 progress))))
          (icon (when (fboundp 'nerd-icons-codicon)
                  (nerd-icons-codicon "nf-cod-sync"))))
-
-    (if (string-blank-p percent)
-        ;; If no percentage found, return empty (or a minimal label if needed)
-        ""
-      ;; Final format: Icon + Percentage
-      ;; We remove the inner parentheses for a cleaner look, e.g., "96%%"
-      (format "%s %s"
-              (or icon "")
-              (replace-regexp-in-string "[()]" "" percent)))))
+    (cond
+     ;; Both stage and percent
+     ((and stage (not (string-blank-p percent)))
+      (format "%s %s %s" (or icon "") stage percent))
+     ;; Only stage
+     (stage
+      (format "%s %s" (or icon "") stage))
+     ;; Fallback
+     (t ""))))
 
 ;;; Mode-line
 ;;;


### PR DESCRIPTION
Close #1298: Show LSP initialization progress in mode-line

## What this PR does

During rust-analyzer initialization, lsp-bridge now displays real-time progress in the mode-line of affected buffers, so users can tell whether the LSP is still loading rather than wondering if it has failed silently.

Try to improve cursor positioning for type inlay hints

## Changes

**`core/lspserver.py`**

- Pass `file_paths` (the list of files currently open in the server) as an additional argument to `lsp-bridge--record-work-done-progress`, so the progress indicator is only shown in buffers that belong to the server currently loading

**`lsp-bridge.el`**

- New buffer-local variable `lsp-bridge--work-done-progress` and `lsp-bridge--work-done-progress-timer` so each buffer tracks its own progress state independently
- Update `lsp-bridge--record-work-done-progress` to iterate over `file-paths` and update only the matching buffers, with a 1-second auto-clear timer per buffer
- Add `lsp-bridge--format-progress-message` to format the raw progress string: extracts stage name and percentage, strips the `[LSP-Bridge]` prefix and `rustAnalyzer/` namespace, and shows a nerd-icons icon when available
- Update `lsp-bridge--mode-line-format` to render the buffer-local progress string alongside the existing `lsp-bridge` label

Clears automatically once loading is complete.

## Notes

- Works for any LSP server that emits `$/progress` notifications, not just rust-analyzer
- Progress is shown only in buffers belonging to the loading server, not globally
- The existing `acm-backend-lsp-show-progress` behavior is preserved

## Try to improve cursor positioning for type inlay hints

When moving the cursor rightward through a line with type inlay hints (InlayHintKind=1), the cursor previously jumped past the entire hint text, which was visually jarring. This is a known issue with Emacs `before-string' overlays (ref: emacs-lsp/lsp-mode#3263).

The fix applies the `cursor 1' text property to all type hint overlays, so the cursor stops at the beginning of the hint instead of skipping over it.