### PR TITLE
fix: improve remote connection recovery after disconnect

### DIFF
--- a/core/remote_file.py
+++ b/core/remote_file.py
@@ -479,13 +479,21 @@ class FileElispServer(RemoteFileServer):
         # remote server lsp-bridge process use this cient_socket to call elisp function from local Emacs.
         log_time(f"Client connect from {self.client_address[0]}:{self.client_address[1]}")
 
-        self.rpcs.clear()
+        for rpc in self.rpcs.values():
+            rpc["result"] = None
+            rpc["completion"].set()
+
+        self.lsp_bridge.init_search_backends_complete_event.clear()
+
         threading.Thread(target=super().handle_client).start()
 
-        self.lsp_bridge.init_search_backends()
-        log_time("init_search_backends finish")
-        # Signal that init_search_backends is done
-        self.lsp_bridge.init_search_backends_complete_event.set()
+        try:
+            self.lsp_bridge.init_search_backends()
+            log_time("init_search_backends finish")
+        except Exception:
+            logger.exception("init_search_backends failed")
+        finally:
+            self.lsp_bridge.init_search_backends_complete_event.set()
 
     def handle_message(self, message):
         if message == "Connect":
@@ -505,6 +513,7 @@ class FileElispServer(RemoteFileServer):
             self.send_message(message)
         except Exception as e:
             logger.exception(e)
+            del self.rpcs[ts]
             return None
         else:
             cpl.wait()
@@ -526,10 +535,6 @@ class FileCommandServer(RemoteFileServer):
         self.lsp_bridge.init_search_backends_complete_event.wait()
 
         super().handle_client()
-
-        # close all files when client disconnects
-        self.lsp_bridge.file_server.close_all_files()
-        self.lsp_bridge.close_all_files()
 
     def handle_message(self, message):
         if message["command"] == "lsp_request":

--- a/lsp_bridge.py
+++ b/lsp_bridge.py
@@ -273,6 +273,13 @@ class LspBridge:
         if server_host in self.host_ip_dict:
             server_host = self.host_ip_dict[server_host]
 
+        if server_host not in self.host_names and is_valid_ip(server_host):
+            for known_host, conf in self.host_names.items():
+                if conf.get('hostname') == server_host:
+                    self.host_ip_dict[server_host] = known_host
+                    server_host = known_host
+                    break
+
         if server_host not in self.host_names:
             message_emacs(f"{server_host} is not connected, try reconnect...")
             self.sync_tramp_remote_complete_event.clear()
@@ -372,7 +379,7 @@ class LspBridge:
                     else:
                         # connection restored, try to send out the message
                         client.send_message(data["message"])
-                        eval_in_emacs('lsp-bridge-remote-reconnect', server_host, False)
+                        eval_in_emacs('lsp-bridge-remote-reconnect', server_host, True)
                 except Exception as e:
                     logger.exception(e)
                 finally:


### PR DESCRIPTION
1. When ~/.ssh/config is used, Host and IP mismatch during reconnection, preventing channel recovery. Fixed by reverse look-up in SSH config.
2. LSP servers were killed on channel disconnect but not restarted after reconnect.  Fixed by removing the kill on disconnect. 
3. Fix some potential deadlock on reconnect.