### PR TITLE
feat: C-c ' (org-edit-special) buffer LSP support via org-src-source-file-name

### DIFF
--- a/core/lspserver.py
+++ b/core/lspserver.py
@@ -519,7 +519,10 @@ class LspServer:
         (relative to project root) that the .org content should masquerade as,
         e.g. "src/main.rs" for rust-analyzer."""
         if filepath.endswith('.org') and "orgBabelVirtualFile" in self.server_info:
-            virtual_file = os.path.join(self.project_path, self.server_info["orgBabelVirtualFile"])
+            base = self.project_path
+            if not os.path.isdir(base):
+                base = os.path.dirname(base)
+            virtual_file = os.path.join(base, self.server_info["orgBabelVirtualFile"])
             return path_to_uri(virtual_file)
         return path_to_uri(filepath)
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -125,10 +125,13 @@ def get_lsp_file_host():
 def get_buffer_content(filename, buffer_name):
     global lsp_bridge_server
 
+    content = ""
     if lsp_bridge_server and lsp_bridge_server.file_server:
-        return lsp_bridge_server.file_server.get_file_content(filename)
-    else:
-        return get_emacs_func_result('get-buffer-content', buffer_name)
+        content = lsp_bridge_server.file_server.get_file_content(filename)
+    if not content:
+        # Fallback to Emacs buffer for local files (e.g. org-babel)
+        content = get_emacs_func_result('get-buffer-content', buffer_name)
+    return content
 
 def get_file_content_from_file_server(filename):
     global lsp_bridge_server

--- a/lsp-bridge-peek.el
+++ b/lsp-bridge-peek.el
@@ -426,7 +426,16 @@ The beginnings of each symbol are replaced by ace strings with
     (if (not (member buf-name lsp-bridge-peek--temp-buffer-alist))
 	    (let ((buf (generate-new-buffer buf-name)))
 	      (with-current-buffer buf
-	        (insert-file-contents file)
+	        (let ((file-size
+	               (condition-case nil
+	                   (cadr (insert-file-contents file))
+	                 (file-error 0))))
+	          (when (and (= file-size 0)
+	                     (boundp 'my/peek-src-buffer)
+	                     (buffer-live-p my/peek-src-buffer))
+	            ;; Virtual file (e.g. org-babel src/main.groovy) is empty
+	            ;; or doesn't exist: use the stored C-c ' buffer content.
+	            (insert-buffer-substring my/peek-src-buffer)))
 	        (let ((buffer-file-name file))
 	          (delay-mode-hooks
 		        (set-auto-mode)))

--- a/lsp-bridge.el
+++ b/lsp-bridge.el
@@ -1050,7 +1050,9 @@ So we build this macro to restore postion after code format."
        lsp-bridge-remote-file-flag))
 
 (defun lsp-bridge-get-buffer-file-name-text ()
-  (lsp-bridge-buffer-file-name buffer-file-name))
+  (or (lsp-bridge-buffer-file-name buffer-file-name)
+      (when (bound-and-true-p org-src-mode)
+        org-src-source-file-name)))
 
 (defun lsp-bridge-buffer-file-name (name)
   ;; `buffer-file-name' may contain face property, we need use `substring-no-properties' remove those face from buffer name.
@@ -1155,7 +1157,23 @@ So we build this macro to restore postion after code format."
         (and lsp-bridge-org-babel--info-cache
              (org-element-property :value lsp-bridge-org-babel--info-cache))
       (with-current-buffer buf
-        (buffer-substring-no-properties (point-min) (point-max))))))
+        (if (and (eq major-mode 'org-mode) buffer-file-name)
+            ;; Org buffer: prefer active C-c ' sub-buffer content.
+            ;; When a C-c ' buffer is editing a src block in this org file,
+            ;; return the pure src block content (no org markup).
+            (let ((c-sub (car (delq nil
+                              (mapcar (lambda (b)
+                                        (with-current-buffer b
+                                          (when (and (bound-and-true-p org-src-mode)
+                                                     org-src--beg-marker
+                                                     (eq (marker-buffer org-src--beg-marker) buf))
+                                            b)))
+                                      (buffer-list))))))
+              (if c-sub
+                  (with-current-buffer c-sub
+                    (buffer-substring-no-properties (point-min) (point-max)))
+                (buffer-substring-no-properties (point-min) (point-max))))
+          (buffer-substring-no-properties (point-min) (point-max)))))))
 
 (defun lsp-bridge--get-current-line-func ()
   (buffer-substring-no-properties (line-beginning-position) (line-end-position)))
@@ -1251,19 +1269,40 @@ So we build this macro to restore postion after code format."
     (lsp-bridge-get-symbol-string-value (cdr langserver-info))))
 
 (defun lsp-bridge-get-single-lang-server-by-file-mode (filename)
-  "Get lang server for file mode."
-  (let* ((mode (lsp-brige-get-mode filename))
-         (langserver-info (lsp-bridge-lang-server-by-mode mode lsp-bridge-single-lang-server-mode-list)))
-    (cond (langserver-info
-           (lsp-bridge-get-symbol-string-value (cdr langserver-info)))
-          ((eq mode 'org-mode)
-           (cond
-            (lsp-bridge-use-wenls-in-org-mode
-             "wen")
-            (lsp-bridge-use-ds-pinyin-in-org-mode
-             "ds-pinyin")
-            (lsp-bridge-enable-org-babel
-             (lsp-bridge-org-babel-check-lsp-server)))))))
+  "Get lang server for file mode.
+For .org files, scan all buffers for an active C-c ' (org-src-mode)
+sub-buffer editing this file and use its major-mode (e.g.
+groovy-mode) for server lookup.  This avoids depending on the
+calling buffer's local variables, which may not be set when
+Python queries get-single-lang-server."
+  (if (string-suffix-p ".org" filename)
+      (let ((c-sub (car (delq nil
+                        (mapcar (lambda (b)
+                                  (with-current-buffer b
+                                    (when (and (bound-and-true-p org-src-mode)
+                                               org-src--beg-marker
+                                               (let ((obuf (marker-buffer org-src--beg-marker)))
+                                                 (and obuf (equal (buffer-file-name obuf) filename))))
+                                      b)))
+                                (buffer-list))))))
+        (when c-sub
+          (with-current-buffer c-sub
+            (when-let* ((info (lsp-bridge-lang-server-by-mode
+                               major-mode
+                               lsp-bridge-single-lang-server-mode-list)))
+              (lsp-bridge-get-symbol-string-value (cdr info))))))
+    (let* ((mode (lsp-brige-get-mode filename))
+           (langserver-info (lsp-bridge-lang-server-by-mode mode lsp-bridge-single-lang-server-mode-list)))
+      (cond (langserver-info
+             (lsp-bridge-get-symbol-string-value (cdr langserver-info)))
+            ((eq mode 'org-mode)
+             (cond
+              (lsp-bridge-use-wenls-in-org-mode
+               "wen")
+              (lsp-bridge-use-ds-pinyin-in-org-mode
+               "ds-pinyin")
+              (lsp-bridge-enable-org-babel
+               (lsp-bridge-org-babel-check-lsp-server))))))))
 
 (defun lsp-bridge-has-lsp-server-p ()
   (cond ((and lsp-bridge-enable-org-babel (eq major-mode 'org-mode))


### PR DESCRIPTION
## Problem

When editing an org-mode src block via `C-c '` (org-edit-special), the buffer has:

- **No `buffer-file-name`** — org-mode creates it as a pure in-memory buffer
- **No file extension** matching the language — it may be named `*Org Src file.org[ groovy ]*`
- **A temporary `org-src-source-file-name`** — org-mode sets this buffer-local variable to the original `.org` file path

Before this PR, lsp-bridge could not determine the correct LSP server for such buffers, so features like auto-completion, `lsp-bridge-find-def`, and `lsp-bridge-peek` either failed silently or required hacky temp file workarounds that broke peek.

## Solution

The fix has three layers:

### Layer 1: Python (core/)
Already submitted as the initial commit. Two fixes:

- **`core/utils.py`** — `get_buffer_content()`: when `file_server` has no content for a local file, fall back to `get_emacs_func_result('get-buffer-content', buffer_name)`. This ensures Emacs buffer content is used for `.org` files that are not cached in the file server.
- **`core/lspserver.py`** — `get_document_uri()`: when `project_path` is a file (e.g. an `.org` file opened outside a git repo), use `os.path.dirname(project_path)` as the base for `orgBabelVirtualFile` path, preventing paths like `/path/to/file.org/src/main.groovy`.

### Layer 2: lsp-bridge.el (Emacs core)
Three changes that make lsp-bridge aware of `C-c '` buffers via `org-src-source-file-name` — a buffer-local variable that org-mode already sets to the original `.org` file path (see org-src.el line 585: `(setq org-src-source-file-name (buffer-file-name (buffer-base-buffer)))`, documented as "a utility variable used by LSP and other packages").

1. **`lsp-bridge-get-buffer-file-name-text`** — fall back to `org-src-source-file-name` when `buffer-file-name` is nil. This makes `acm-backend-lsp-filepath`, `lsp-bridge-has-lsp-server-p`, and Python`'s `get-single-lang-server` all work with the `.org` path:

```elisp
(defun lsp-bridge-get-buffer-file-name-text ()
  (or (lsp-bridge-buffer-file-name buffer-file-name)
      (when (bound-and-true-p org-src-mode)
        org-src-source-file-name)))
```

2. **`lsp-bridge-get-single-lang-server-by-file-mode`** — for `.org` files, scan all buffers for an active `C-c '` sub-buffer (identified by `org-src-mode` + `org-src--beg-marker`) and use its `major-mode` to look up the LSP server. This is necessary because the function may be called from any Emacs buffer context, not necessarily the `C-c '` buffer itself:

```elisp
(defun lsp-bridge-get-single-lang-server-by-file-mode (filename)
  (if (string-suffix-p ".org" filename)
      (let ((c-sub (car (delq nil
                        (mapcar (lambda (b)
                                  (with-current-buffer b
                                    (when (and (bound-and-true-p org-src-mode)
                                               org-src--beg-marker
                                               (let ((obuf (marker-buffer org-src--beg-marker)))
                                                 (and obuf (equal (buffer-file-name obuf) filename))))
                                      b)))
                                (buffer-list))))))
        (when c-sub
          (with-current-buffer c-sub
            (when-let* ((info (lsp-bridge-lang-server-by-mode
                               major-mode
                               lsp-bridge-single-lang-server-mode-list)))
              (lsp-bridge-get-symbol-string-value (cdr info))))))
    ...original logic...))
```

3. **`lsp-bridge--get-buffer-content-func`** — when called with an org buffer name (during `read_file()` / `didOpen`), scan for an active `C-c '` sub-buffer and return its content instead of the full org file markup:

```elisp
(defun lsp-bridge--get-buffer-content-func (buffer-name &optional no-org-babel)
  (when-let* ((buf (get-buffer buffer-name)))
    (if (and lsp-bridge-enable-org-babel ...)
        ...existing logic...
      (with-current-buffer buf
        (if (and (eq major-mode 'org-mode) buffer-file-name)
            ;; Check for active C-c ' sub-buffer
            (let ((c-sub (car (delq nil
                              (mapcar (lambda (b)
                                        (with-current-buffer b
                                          (when (and org-src-mode
                                                     org-src--beg-marker
                                                     (eq (marker-buffer org-src--beg-marker) buf))
                                            b)))
                                      (buffer-list))))))
              (if c-sub
                  (with-current-buffer c-sub
                    (buffer-substring-no-properties (point-min) (point-max)))
                (buffer-substring-no-properties (point-min) (point-max))))
          (buffer-substring-no-properties (point-min) (point-max)))))))
```

### Layer 3: lsp-bridge-peek.el (Emacs peek)
`lsp-bridge-peek` reads file content from disk via `insert-file-contents`. For `orgBabelVirtualFile` paths (e.g. `src/main.groovy` generated by the server config), the file either doesn't exist or exists as an empty placeholder. The fix checks if the inserted content is zero bytes and falls back to the stored `C-c '` buffer content:

```elisp
;; Inside lsp-bridge-peek--file-content:
(let ((file-size
       (condition-case nil
           (cadr (insert-file-contents file))
         (file-error 0))))
  (when (and (= file-size 0)
             (boundp 'my/peek-src-buffer)
             (buffer-live-p my/peek-src-buffer))
    (insert-buffer-substring my/peek-src-buffer)))
```

The `my/peek-src-buffer` variable is set before each peek call by an `:around` advice on `lsp-bridge-peek`.

## User-Side Configuration (emacs-settings)

To activate these changes, the user's config does the following (example code, not part of lsp-bridge itself):

1. **Simplifies `my/org-edit-lsp-init`** — no `buffer-file-name` hacking. Just restarts lsp-bridge-mode (so it picks up `org-src-source-file-name`) and calls `update_file`:

```elisp
(defun my/org-edit-lsp-init ()
  (when (and (bound-and-true-p org-src-mode)
             (not (eq major-mode 'org-mode))
             (bound-and-true-p org-src-source-file-name))
    (when (bound-and-true-p lsp-bridge-mode)
      (lsp-bridge-mode -1) (lsp-bridge-mode 1))
    (lsp-bridge-call-file-api "update_file" (buffer-name))))
```

2. **Stores `C-c '` buffer reference** before peek calls (via `:around` advice):

```elisp
(defvar my/peek-src-buffer nil)
(defun my/lsp-bridge--trace-init (orig-fun &rest args)
  (when (and (bound-and-true-p org-src-mode)
             (eq this-command 'lsp-bridge-peek))
    (setq my/peek-src-buffer (current-buffer)))
  (apply orig-fun args))
(advice-add 'lsp-bridge-peek :around #'my/lsp-bridge--trace-init)
```

3. **Redirects peek-jump (RET)** — when the LSP response contains a virtual file path (e.g. `.../src/main.groovy` from `orgBabelVirtualFile`), staying in the `C-c '` buffer instead of opening an empty file:

```elisp
(defun my/lsp-bridge-jump-advice (orig-fun file position)
  (if (and my/peek-src-buffer
           (buffer-live-p my/peek-src-buffer)
           (with-current-buffer my/peek-src-buffer org-src-mode))
      (with-current-buffer my/peek-src-buffer
        (goto-char (acm-backend-lsp-position-to-point position)))
    (funcall orig-fun file position)))
(advice-add 'lsp-bridge-jump-to-file :around #'my/lsp-bridge-jump-advice)
```

## Design Notes

- **Zero disk files**: No temp files are created. The `C-c '` buffer remains purely in-memory.
- **Uses org-mode built-in variables**: `org-src-source-file-name` and `org-src--beg-marker` are standard org-mode variables, not custom additions.
- **No `lsp-bridge-enable-org-babel` dependency**: Works independently of the existing org-babel module, which is designed for editing directly in the org-mode buffer (not `C-c '` buffers).
- **`groovy-language-server.json` addition**: Users should add `"orgBabelVirtualFile": "src/main.groovy"` to their language server config to enable project-aware features in `.org` files.

## Testing

Tested with:
- groovy src blocks in `.org` files within a real Gradle project
- python, bash src blocks (basic)
- Fresh Emacs, no temp files created

Operations verified:
- `lsp-bridge-mode` activates with correct language server
- Auto-completion works
- `lsp-bridge-find-def` returns correct results
- `lsp-bridge-peek` shows source code in popup
- `lsp-bridge-peek-jump` (RET) stays in `C-c '` buffer
- No disk files created for any of these operations
