### PR TITLE
fix: preserve sortText for LSP spec compliance

### DIFF
--- a/core/handler/completion.py
+++ b/core/handler/completion.py
@@ -33,7 +33,10 @@ class Completion(Handler):
         return dict(position=position, context=context)
 
     def parse_sort_value(self, sort_text):
-        return ''.join(c for c in sort_text if c.isdigit() or c == '.').rstrip('.')
+        # Return sortText as-is per LSP spec (lexicographic comparison).
+        # Some LSP servers (e.g. Eclipse JDT.LS) use letter-prefixed sortText
+        # like "A0" for classes and "B0" for variables to encode type priority.
+        return sort_text
 
     def compare_candidates(self, x, y):
         prefix = self.prefix.lower()


### PR DESCRIPTION
## Problem

`parse_sort_value()` was stripping non-digit characters from sortText, which broke type-based ranking for LSP servers like Eclipse JDT.LS that use letter-prefixed sortText (e.g. 'A0' for classes, 'B0' for variables).

## Root Cause

JDT.LS uses sortText like:
- `"A0"` — classes/interfaces
- `"B0"` — variables/fields/methods

After `parse_sort_value()` processing, both became `"0"`, losing the type priority information. The fallback to label length caused shorter variable names to appear above longer class names.

## Fix

Return sortText as-is per LSP spec (lexicographic comparison). The LSP specification defines sortText as a string used for lexicographic sorting, so clients should not modify it.

## Impact

- Fixes completion ordering for Eclipse JDT.LS (Java), Eclipse CDT (C/C++), and other Eclipse-based LSP servers
- No impact on other LSP servers that use numeric sortText (comparison still works correctly)